### PR TITLE
feat(baradur) hyprland lua migration + macchiato-glass desktop

### DIFF
--- a/data/permitted-insecure-packages.nix
+++ b/data/permitted-insecure-packages.nix
@@ -1,0 +1,7 @@
+[
+  "electron-38.8.4"
+  "electron-40.10.5" # cherry-studio (EOL; bundled upstream)
+  "nodejs-20.20.2"
+  "nodejs-slim-20.20.2"
+  "pnpm-10.29.2"
+]

--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780756231,
-        "narHash": "sha256-tXQxKdG5716uB9/LIkLQqQwHKf5mRSpHoZhz3lyI2Cg=",
+        "lastModified": 1784368054,
+        "narHash": "sha256-zF1iJkBQSDWmRO4/LEeHR1SpKY0lqZaxkoQJpPS9K9U=",
         "owner": "hyprwm",
         "repo": "aquamarine",
-        "rev": "6ecde03f47172753fe5a2f334f9d3facfb7e6784",
+        "rev": "9b5f14d9483445e766294eb8fbe0b8f370269ed0",
         "type": "github"
       },
       "original": {
@@ -142,16 +142,16 @@
     "brew-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1779646357,
-        "narHash": "sha256-rnnAaESXxItX4D9xCMGvs3hfDBjbbTYht7OluRcvT8k=",
+        "lastModified": 1784558651,
+        "narHash": "sha256-woXJ1ATKpSYRWCy46TQJjmm9XzAeZVEZw9xDfVG9NYI=",
         "owner": "Homebrew",
         "repo": "brew",
-        "rev": "10a163ac127624caa80cc5cc5a705e97f3615b0e",
+        "rev": "b48c7994b5f0eed7bef532efa63cb4e4f763887a",
         "type": "github"
       },
       "original": {
         "owner": "Homebrew",
-        "ref": "5.1.14",
+        "ref": "6.0.12",
         "repo": "brew",
         "type": "github"
       }
@@ -163,11 +163,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780795403,
-        "narHash": "sha256-AkWx4Zt9pQbD/f82Z8N57+d0HGLN/rV3gdMKJTpBPKs=",
+        "lastModified": 1784500460,
+        "narHash": "sha256-UvORnAxTRHax7RG74W8Z2t4GvIkX6AjJ5kk0QlwZomo=",
         "owner": "nix-darwin",
         "repo": "nix-darwin",
-        "rev": "6a771120d607dcccb279a27d227650e324815c35",
+        "rev": "57a3171f94705599a2499248ca5758d5eb47c0e0",
         "type": "github"
       },
       "original": {
@@ -185,11 +185,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1780985971,
-        "narHash": "sha256-BNCh7LUjcEtID2M3pbzPcwQCmZlsFPpw0I8sKQSboEw=",
+        "lastModified": 1784907994,
+        "narHash": "sha256-QThLpq2kUT9Pfsaj+fWWRsjqiyw3+P++MdwGwrkZVc0=",
         "owner": "nix-community",
         "repo": "ethereum.nix",
-        "rev": "22a8956de91cc275b7f7ae75024c78e1b8fe0721",
+        "rev": "5c4bcbc5063ae15afe596a07b6ffd34de63cb79d",
         "type": "github"
       },
       "original": {
@@ -201,11 +201,11 @@
     "firefox-gnome-theme": {
       "flake": false,
       "locked": {
-        "lastModified": 1779670703,
-        "narHash": "sha256-UdfMivNMwCCqQsYDg5pSz8X2IOaOrIZLIIy+Bg3CO2o=",
+        "lastModified": 1782007937,
+        "narHash": "sha256-PbnJr+eB+9Czol3ReI83dUgEhcn0sDK6TSy6ODTQm88=",
         "owner": "rafaelmardojai",
         "repo": "firefox-gnome-theme",
-        "rev": "942159e73e40bf785816f7f1f5feed9ef3d7c8f9",
+        "rev": "981bd332015397fb1ca033fa982bd61635160c78",
         "type": "github"
       },
       "original": {
@@ -269,11 +269,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778716662,
-        "narHash": "sha256-m1Yf0wZ8j1OHjTc2UwHwyQRSnNeSgLJOd7q5Y45hzi4=",
+        "lastModified": 1782949081,
+        "narHash": "sha256-vp6Y/Grm98ESt6ceOkWiHWyZRDV3J1RID4w+6NWK9yA=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "f7c1a2d347e4c52d5fb8d10cb4d94b5884e546fb",
+        "rev": "17c9d6cdfc60c64f4ee8d306f9bc0b4ccb51481e",
         "type": "github"
       },
       "original": {
@@ -335,43 +335,23 @@
         "type": "github"
       }
     },
-    "gitignore": {
-      "inputs": {
-        "nixpkgs": [
-          "hyprland",
-          "pre-commit-hooks",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1709087332,
-        "narHash": "sha256-HG2cCnktfHsKV0s4XW83gU3F57gaTljL9KNSuG6bnQs=",
-        "owner": "hercules-ci",
-        "repo": "gitignore.nix",
-        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hercules-ci",
-        "repo": "gitignore.nix",
-        "type": "github"
-      }
-    },
     "gnome-shell": {
       "flake": false,
       "locked": {
-        "lastModified": 1767737596,
-        "narHash": "sha256-eFujfIUQDgWnSJBablOuG+32hCai192yRdrNHTv0a+s=",
+        "host": "gitlab.gnome.org",
+        "lastModified": 1776175984,
+        "narHash": "sha256-RJFlFW8GiMei6oqUGrMkGEvVqOH8U7Q8abc1yK4VKD8=",
         "owner": "GNOME",
         "repo": "gnome-shell",
-        "rev": "ef02db02bf0ff342734d525b5767814770d85b49",
-        "type": "github"
+        "rev": "e0fdc4c13250e9a9b8ea9594c83925274f4a5dca",
+        "type": "gitlab"
       },
       "original": {
+        "host": "gitlab.gnome.org",
         "owner": "GNOME",
+        "ref": "50.1",
         "repo": "gnome-shell",
-        "rev": "ef02db02bf0ff342734d525b5767814770d85b49",
-        "type": "github"
+        "type": "gitlab"
       }
     },
     "home-manager": {
@@ -381,11 +361,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781102921,
-        "narHash": "sha256-RnV6ngnudMp9tmfl9Wyrjnk84NkkzbJpuJKQ7bp0wHE=",
+        "lastModified": 1784913159,
+        "narHash": "sha256-JWq0BfjO4ktpH5USfQNQzdvHpIDT8fSKD5K7LvdMRFs=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "74887eaee2995bbdba1f0fbd64e43c1d14a86eca",
+        "rev": "079a3b5d1aa6a719920a51316253b7d6dd22738d",
         "type": "github"
       },
       "original": {
@@ -413,11 +393,11 @@
     "homebrew-cask": {
       "flake": false,
       "locked": {
-        "lastModified": 1781104999,
-        "narHash": "sha256-UZ4VWajGE9l0cTlT61MXHh+ZNEfhBMZFP3r/P5wJZb4=",
+        "lastModified": 1784909428,
+        "narHash": "sha256-qxE+QPtpuhb2zIj69mBdCcVqjfeWI5NIy2VuAuiKLVI=",
         "owner": "homebrew",
         "repo": "homebrew-cask",
-        "rev": "5f7169fe59ed718048532d63a0ac55362e2f3400",
+        "rev": "ced718969d74f5d5fdf898a92566af686c6439fe",
         "type": "github"
       },
       "original": {
@@ -429,11 +409,11 @@
     "homebrew-core": {
       "flake": false,
       "locked": {
-        "lastModified": 1781105063,
-        "narHash": "sha256-U6oq24AjgiZMQubuntkDYNE9ZlI0GSGehoINzm1m2z8=",
+        "lastModified": 1784915103,
+        "narHash": "sha256-KESGtLT33AZ0t1Z6uUxcH0OO13TJwfYb+aA8gKMDz5I=",
         "owner": "homebrew",
         "repo": "homebrew-core",
-        "rev": "06cb9e98ef25d53e233e62aef93995ab02cfa98a",
+        "rev": "92da21be9e76dc86d5df8b6fee5bcd56effa6fd1",
         "type": "github"
       },
       "original": {
@@ -487,11 +467,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776426399,
-        "narHash": "sha256-RUESLKNikIeEq9ymGJ6nmcDXiSFQpUW1IhJ245nL3xM=",
+        "lastModified": 1782566056,
+        "narHash": "sha256-haEZcHzYrePnjFOYSWTbxm/Nrla0aPslJfmvdCvqtVc=",
         "owner": "hyprwm",
         "repo": "hyprgraphics",
-        "rev": "68d064434787cf1ed4a2fe257c03c5f52f33cf84",
+        "rev": "c6e7b9f673f4360bc813d3dc75028f75ee88d3f8",
         "type": "github"
       },
       "original": {
@@ -517,11 +497,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1781108245,
-        "narHash": "sha256-NJIZc18E8sN5xQVDsDtXcQuDE3UBHVz2x9QZf4zbR6U=",
+        "lastModified": 1784897480,
+        "narHash": "sha256-m8Pl1y/VbL45ZzZtitjVEZWo20L3rQ7Egyzjn+b+hoA=",
         "owner": "hyprwm",
         "repo": "Hyprland",
-        "rev": "a80e89fcba84c194f2e7a60ed7da4f5764f39404",
+        "rev": "566ff8fa7208f7027cbc21b0b208d121ee80eb38",
         "type": "github"
       },
       "original": {
@@ -563,11 +543,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776426575,
-        "narHash": "sha256-KI6nIfVihn/DPaeB5Et46Xg3dkNHrrEtUd5LBBVomB0=",
+        "lastModified": 1784196523,
+        "narHash": "sha256-ahtKMGXFJdlQNhatQm1+BBU/pGfGYnAqQt3vWvq4p8s=",
         "owner": "hyprwm",
         "repo": "hyprland-guiutils",
-        "rev": "a968d211048e3ed538e47b84cb3649299578f19d",
+        "rev": "a6ccb6cb112ed5a244c0191fb972347ecfa893e0",
         "type": "github"
       },
       "original": {
@@ -669,11 +649,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1772462885,
-        "narHash": "sha256-5pHXrQK9zasMnIo6yME6EOXmWGFMSnCITcfKshhKJ9I=",
+        "lastModified": 1782554491,
+        "narHash": "sha256-+p3MlyN/nqRefcf2IckPlGRUn9+hielqpS9XClbLleM=",
         "owner": "hyprwm",
         "repo": "hyprtoolkit",
-        "rev": "9af245a69fa6b286b88ddfc340afd288e00a6998",
+        "rev": "bdba25ced39ea39ab004a8f31593ba0b0ff1ca35",
         "type": "github"
       },
       "original": {
@@ -694,11 +674,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780251518,
-        "narHash": "sha256-fG9xbb1SOAAJ+2kJRakp3ch+BmA/3dEg/K3PoAZTKkw=",
+        "lastModified": 1784323413,
+        "narHash": "sha256-XnAVV+H4f8Xdv0yZcSwJ5kCjLyE8fHxPeLX6a3HSrAU=",
         "owner": "hyprwm",
         "repo": "hyprutils",
-        "rev": "40ede2e7bdec80ba5d4c443160d905e9f841ae5f",
+        "rev": "5f03477ab3a005ff27c527486f551883535aea2f",
         "type": "github"
       },
       "original": {
@@ -769,11 +749,11 @@
         "spectrum": "spectrum"
       },
       "locked": {
-        "lastModified": 1780588968,
-        "narHash": "sha256-zQk+GqLO+T9taIl1UUt3swvaOksWJxL7PL8K0+Fc/Hs=",
+        "lastModified": 1784666190,
+        "narHash": "sha256-xgfS6slV7J3baMooNN1UuBi51RIgg9y0DbCxfSA0668=",
         "owner": "microvm-nix",
         "repo": "microvm.nix",
-        "rev": "4d3fb17437944ea57eef2b9e6108ca777b1209ca",
+        "rev": "fa5340ac684cdce8a22b6d4a0bcebb0cc999275e",
         "type": "github"
       },
       "original": {
@@ -787,11 +767,11 @@
         "brew-src": "brew-src"
       },
       "locked": {
-        "lastModified": 1780492467,
-        "narHash": "sha256-zMEJwtQPmsPPgPczFkyjWHgd1z0HagOPS2Wt2WDYLJY=",
+        "lastModified": 1784906761,
+        "narHash": "sha256-2v0H8+Ert+xbm0oliHblXTPPczuKiibBUBvRax59kxg=",
         "owner": "zhaofengli",
         "repo": "nix-homebrew",
-        "rev": "562332f97de9f5ba51aa647d70462e88222b2988",
+        "rev": "60623ec512406261f553d24033c8a0c53fd0b7f2",
         "type": "github"
       },
       "original": {
@@ -854,11 +834,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1782007105,
-        "narHash": "sha256-oUdsm8POytc0v3OtXadp5WmF3mT+TzYgDjw+N6uzQu0=",
+        "lastModified": 1784434257,
+        "narHash": "sha256-Feyvs5OkNaiG2ymUdOxWirTy9/HPJopywhnwlBIAPiY=",
         "owner": "nvmd",
         "repo": "nixos-raspberrypi",
-        "rev": "16d0e780d5f9546eb7033d420951fd2e3fad76cd",
+        "rev": "2bbb6ee54ed431a59b38d8aa1e254a9e848b7f2b",
         "type": "github"
       },
       "original": {
@@ -869,11 +849,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1780749050,
-        "narHash": "sha256-3av0pIjlOWQ6rDbNOmpUSvbNnJkGORQKKjb4LtCZsIY=",
+        "lastModified": 1784356753,
+        "narHash": "sha256-12KrbMiWLcf8m7pCvAtZh1ZrgF85ZXDXvfR/fWTKy84=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a799d3e3886da994fa307f817a6bc705ae538eeb",
+        "rev": "61b7c44c4073f0b827768aff0049561b5110ea5a",
         "type": "github"
       },
       "original": {
@@ -885,11 +865,11 @@
     },
     "nixpkgs-master": {
       "locked": {
-        "lastModified": 1781110144,
-        "narHash": "sha256-egADZaaqpY8/ijTTDubtnUgPJGzS1KcT8vkQP5qpTmQ=",
+        "lastModified": 1784915261,
+        "narHash": "sha256-oVf1CPzPK6z5cW46c/1ZKNciwX2BIl7qR+NewUjK2OA=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "04efb6a749fcea3bcc6659ef68587d8dd3899f2c",
+        "rev": "fda32d161b04afe212f6fb6d31e9f57a855a9799",
         "type": "github"
       },
       "original": {
@@ -901,27 +881,27 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1781509190,
-        "narHash": "sha256-uJZs9Di8I6ciTp6jiojj0HzlNpBkud8ax5aT/O5aJkw=",
+        "lastModified": 1784280462,
+        "narHash": "sha256-DtoqIqM7VkR6NxAkcLpMwmi02USwWb3JdmNGLyhthc0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d6df3513510aa548c83868fd22bfddd0a8c0a0d4",
+        "rev": "293d6abedf0478e681a4dfcfcb35b30fc796a32f",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-25.11",
+        "ref": "nixos-26.05",
         "repo": "nixpkgs",
         "type": "github"
       }
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1780749050,
-        "narHash": "sha256-3av0pIjlOWQ6rDbNOmpUSvbNnJkGORQKKjb4LtCZsIY=",
+        "lastModified": 1784796856,
+        "narHash": "sha256-wWFrV5/Qbm+lyt5x20E/bSbfJiGKMo4RCxZV8cl/WZI=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "a799d3e3886da994fa307f817a6bc705ae538eeb",
+        "rev": "e2587caef70cea85dd97d7daab492899902dbf5d",
         "type": "github"
       },
       "original": {
@@ -933,11 +913,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1775888245,
-        "narHash": "sha256-nwASzrRDD1JBEu/o8ekKYEXm/oJW6EMCzCRdrwcLe90=",
+        "lastModified": 1782175435,
+        "narHash": "sha256-EMzXKmnOtBQ2MnvpiNOm7E+kOMvdPrIKaeg52Tip2Uk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "13043924aaa7375ce482ebe2494338e058282925",
+        "rev": "89570f24e97e614aa34aa9ab1c927b6578a43775",
         "type": "github"
       },
       "original": {
@@ -959,11 +939,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780281641,
-        "narHash": "sha256-M/+hUKoKbHXpV0xGVfELbN1Ds1aoe3pL5p5/t46YhVo=",
+        "lastModified": 1783439237,
+        "narHash": "sha256-WUr8JF2v3n4Y30E5dxv4sAgNJXpVDBoCQNoQ/V4+n4o=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "30f9ae2f04174de63ba8bcf3580ca90843b28a01",
+        "rev": "b70bb66c7bcd162642f3a609bc16843c7059f503",
         "type": "github"
       },
       "original": {
@@ -975,18 +955,17 @@
     "pre-commit-hooks": {
       "inputs": {
         "flake-compat": "flake-compat",
-        "gitignore": "gitignore",
         "nixpkgs": [
           "hyprland",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1778507602,
-        "narHash": "sha256-kTwur1wV+01SdqskVMSo6JMEpg71ps3HpbFY2GsflKs=",
+        "lastModified": 1784288435,
+        "narHash": "sha256-ReRHaLgr/uVqdD8afFSn+myXIfpHeOhP0yYe0TJqAA8=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "61ab0e80d9c7ab14c256b5b453d8b3fb0189ba0a",
+        "rev": "43b3c1ab9d40fb1dbb008f451988a91e375825e9",
         "type": "github"
       },
       "original": {
@@ -1024,11 +1003,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1765361626,
-        "narHash": "sha256-kX0Dp/kYSRbQ+yd9e3lmmUWdNbipufvKfL2IzbrSpnY=",
+        "lastModified": 1784328457,
+        "narHash": "sha256-4R5WV74NHhPk21ctoPmjL7nQ6txDnoBLwSWULvIw0TY=",
         "owner": "snowfallorg",
         "repo": "lib",
-        "rev": "c566ad8b7352c30ec3763435de7c8f1c46ebb357",
+        "rev": "6ee3542cb459ca4b038cfe50ceb8797f05cdabad",
         "type": "github"
       },
       "original": {
@@ -1042,11 +1021,11 @@
         "nixpkgs": "nixpkgs_4"
       },
       "locked": {
-        "lastModified": 1780547341,
-        "narHash": "sha256-Gq8KNx5A7hBB3uGJaj6eQfLDIz5YdLu92gqBcvHvoUo=",
+        "lastModified": 1783174389,
+        "narHash": "sha256-aCWC8ngycU7OdJrU2+Je3qf+1a2ykuBvpPhZT/9tXMc=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "9ed65852b6257fbeae4355bc24ecfea307ca759a",
+        "rev": "f1406619a3884cd5c47992a70b8b35c9c0fcb4c9",
         "type": "github"
       },
       "original": {
@@ -1058,11 +1037,11 @@
     "spectrum": {
       "flake": false,
       "locked": {
-        "lastModified": 1778940603,
-        "narHash": "sha256-voSM8dZNlaOWN3kbYFky+FNY6fFQOEw0xF+ZMpZKkCQ=",
+        "lastModified": 1783694892,
+        "narHash": "sha256-xO8f7Qng+18FK2UlB9vcrkxCaQMCt5WjCH24aW/11eg=",
         "ref": "refs/heads/main",
-        "rev": "367dd227f539267eae2b62770b4c17b88ac8c1f1",
-        "revCount": 1265,
+        "rev": "24c4346e30fdea8d8e80f34aec3554a15a667d24",
+        "revCount": 1410,
         "type": "git",
         "url": "https://spectrum-os.org/git/spectrum"
       },
@@ -1091,11 +1070,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1781018772,
-        "narHash": "sha256-C+cGIUaC6dqfwTbI+BwCd572PbESGA3WYxR1sLTqxkY=",
+        "lastModified": 1784676123,
+        "narHash": "sha256-ndyanKzw90yX2nUVFmTuYqXidUNymtMfgmIHyNdhht0=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "a378e4c09031fb15a4d65da88aa628f71fc52f6b",
+        "rev": "66714e5ce44269ecc58c20d9196da8dbe1b27a31",
         "type": "github"
       },
       "original": {
@@ -1183,11 +1162,11 @@
     "tinted-schemes": {
       "flake": false,
       "locked": {
-        "lastModified": 1777806186,
-        "narHash": "sha256-PDF0/wObw4nIsSBeXVYLsloXOiphXCgIdsrNcVXguKs=",
+        "lastModified": 1781968807,
+        "narHash": "sha256-yYO3Vw2M0y3TAUqt+9+Mj0zwP3XDTF5/PXcPhhFQ1ZM=",
         "owner": "tinted-theming",
         "repo": "schemes",
-        "rev": "0c94645546f4f3ddac77a1a5fce54eb95bf50795",
+        "rev": "2ccef2f4b22e3cab5a9292811f7133a07eeba4a7",
         "type": "github"
       },
       "original": {
@@ -1199,11 +1178,11 @@
     "tinted-tmux": {
       "flake": false,
       "locked": {
-        "lastModified": 1778379944,
-        "narHash": "sha256-wPDFzMGSlARlw0Sfsn48Q2+jPSfk6N0Ng6BC/d+7Q24=",
+        "lastModified": 1782012462,
+        "narHash": "sha256-2iDiD8DQLwS1lGuD9TS8WlvNyDoTs6krWntJbtB2zGo=",
         "owner": "tinted-theming",
         "repo": "tinted-tmux",
-        "rev": "fe0203a198690e71a5ff11e08812a4673de3678d",
+        "rev": "8c4e750f738a742bd73377ee41d3dadedebedef4",
         "type": "github"
       },
       "original": {
@@ -1215,11 +1194,11 @@
     "tinted-zed": {
       "flake": false,
       "locked": {
-        "lastModified": 1778378178,
-        "narHash": "sha256-OXPXRIQgGwV77HjYRryOHguh4ALX96jkg+tseLkGgHA=",
+        "lastModified": 1782009766,
+        "narHash": "sha256-VUhBjpGvWqHI7rWeyMYb/u87YJSXHKfVV6S+IelWeO8=",
         "owner": "tinted-theming",
         "repo": "base16-zed",
-        "rev": "9cd816033ff969415b190722cddf134e78a5665f",
+        "rev": "5e8350bcd354e3241ab681a265fa6ef060c40be1",
         "type": "github"
       },
       "original": {
@@ -1236,11 +1215,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780220602,
-        "narHash": "sha256-eynAfOmbmxJnkp7YewvCEbShNnnYJ9gLLqkzsYtBPeM=",
+        "lastModified": 1784369104,
+        "narHash": "sha256-47cxbcZODibHv3rELFQ9vZly0vUNkND/atn/U7HLeb0=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "db947814a175b7ca6ded66e21383d938df01c227",
+        "rev": "df3c0640565d04a0261253cdd89fce78ec50168a",
         "type": "github"
       },
       "original": {
@@ -1277,11 +1256,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780133819,
-        "narHash": "sha256-0YPKIY3dlnR7SPq7Z8ekFVvzFsfeiAtEj+QUI3KHrlI=",
+        "lastModified": 1784371182,
+        "narHash": "sha256-S8A1lezEalltWcCp3gAic5lssS0xTSISK6fKODefhOk=",
         "owner": "hyprwm",
         "repo": "xdg-desktop-portal-hyprland",
-        "rev": "4a170c0ba96fd37374f93d8f91c9ed91814828ac",
+        "rev": "08d99f727944dd15e4740090305e31c5fb92a50a",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -108,8 +108,10 @@
         allowUnfree = true;
         permittedInsecurePackages = [
           "electron-38.8.4"
+          "electron-40.10.5" # cherry-studio (EOL; bundled upstream)
           "nodejs-20.20.2"
           "nodejs-slim-20.20.2"
+          "pnpm-10.29.2"
         ];
       };
 

--- a/flake.nix
+++ b/flake.nix
@@ -109,11 +109,19 @@
         permittedInsecurePackages = import ./data/permitted-insecure-packages.nix;
       };
 
+      # @gitian NixOS-wide module injection. Snowfall auto-imports every
+      # modules/nixos/* into every NixOS host, and the geth/microvm modules
+      # reference options declared by these upstream modules — so the option
+      # declarations must exist on every host, not just the ones that enable
+      # them. Importing is inert until a host flips the corresponding enables.
+      systems.modules.nixos = with inputs; [
+        ethereum-nix.nixosModules.default
+        microvm.nixosModules.host
+      ];
+
       # @gitian:host baradur — x86_64-linux desktop (Hyprland, Nvidia, Ollama, Steam).
       # Imports ethereum-nix for potential validator/node operation.
       systems.hosts.baradur.modules = with inputs; [
-        ethereum-nix.nixosModules.default
-        microvm.nixosModules.host
         (
           { pkgs, system, ... }:
           {
@@ -128,10 +136,13 @@
         )
       ];
 
-      # @gitian:host helms-deep — aarch64-linux microVM host (RPi5 / arm server).
-      systems.hosts.helms-deep.modules = with inputs; [
-        microvm.nixosModules.host
-      ];
+      # @gitian:host agent — aarch64-linux RPi5, currently on the mainline
+      # kernel (its unpinned third-party nix-rpi5 fetchTarball broke pure
+      # evaluation and was removed). The vendor kernel/firmware comes back via
+      # nixos-raspberrypi in the pi-netboot plan's Phase 5 — as of 2026-07-24
+      # that input (rev 2bbb6ee) cannot be mixed into a host on current
+      # nixos-unstable (vendor kernel lacks buildDTBs/target passthru; its
+      # legacyPackages cross-evaluates badly against the newer module set).
 
       # @gitian:host dbook — aarch64-darwin minimal macOS config.
       # Bootstraps nix-rosetta-builder for x86_64 cross-compilation on Apple Silicon.

--- a/flake.nix
+++ b/flake.nix
@@ -106,13 +106,7 @@
 
       channels-config = {
         allowUnfree = true;
-        permittedInsecurePackages = [
-          "electron-38.8.4"
-          "electron-40.10.5" # cherry-studio (EOL; bundled upstream)
-          "nodejs-20.20.2"
-          "nodejs-slim-20.20.2"
-          "pnpm-10.29.2"
-        ];
+        permittedInsecurePackages = import ./data/permitted-insecure-packages.nix;
       };
 
       # @gitian:host baradur — x86_64-linux desktop (Hyprland, Nvidia, Ollama, Steam).

--- a/homes/x86_64-linux/arrayofone/default.nix
+++ b/homes/x86_64-linux/arrayofone/default.nix
@@ -23,6 +23,7 @@ in
     hypridle.enable = true;
     hyprland.enable = true;
     hyprlock.enable = true;
+    rofi.enable = true;
     waybar.enable = true;
 
     brave.enable = true;
@@ -38,6 +39,7 @@ in
     webcord.enable = true;
 
     dev.enable = true;
+    packages.claudeCodeFromMaster = true;
   };
 
   home = {

--- a/homes/x86_64-linux/arrayofone/default.nix
+++ b/homes/x86_64-linux/arrayofone/default.nix
@@ -25,6 +25,7 @@ in
     hyprlock.enable = true;
     rofi.enable = true;
     waybar.enable = true;
+    waybar.timezone = "America/Vancouver";
 
     brave.enable = true;
     firefox.enable = true;

--- a/modules/home/dunst/default.nix
+++ b/modules/home/dunst/default.nix
@@ -16,7 +16,6 @@ in
   config = lib.mkIf cfg.enable {
     home = {
       packages = with pkgs; [
-        dunst
         libnotify
       ];
     };
@@ -80,10 +79,15 @@ in
           # notification_limit).
           indicate_hidden = "yes";
 
-          # The transparency of the window.  Range: [0; 100].
-          # This option will only work if a compositing window manager is
-          # present (e.g. xcompmgr, compiz, etc.). (X11 only)
-          transparency = 5;
+          ### Colors (Catppuccin Macchiato glass) ###
+
+          # Glass card: mantle at ~90% alpha; the Hyprland dunst layer_rule
+          # blur frosts whatever is behind the notification.
+          background = "#1e2030E6";
+          foreground = "#cad3f5";
+
+          # Progress bar: mauve → blue accent gradient
+          highlight = "#c6a0f6, #8aadf4";
 
           # Draw a line of "separator_height" pixel height between two
           # notifications.
@@ -105,13 +109,13 @@ in
           frame_width = 2;
 
           # Defines color of the frame around the notification window.
-          frame_color = "#ca9ee6";
+          frame_color = "#c6a0f6";
 
           # Size of gap to display between notifications - requires a compositor.
           # If value is greater than 0, separator_height will be ignored and a border
           # of size frame_width will be drawn around each notification instead.
           # Click events on gaps do not currently propagate to applications below.
-          gap_size = 8;
+          gap_size = 10;
 
           # Define a color for the separator.
           # possible values are:
@@ -133,7 +137,7 @@ in
 
           ### Text ###
 
-          # font = "Intel One Mono";
+          font = "Ubuntu Sans 11";
 
           # The spacing between lines.  If the height is smaller than the
           # font height, it will get raised to the font height.
@@ -208,7 +212,7 @@ in
 
           # Recursive icon lookup. You can set a single theme, instead of having to
           # define all lookup paths.
-          #enable_recursive_icon_lookup = true
+          enable_recursive_icon_lookup = true;
 
           # Set icon theme (only used for recursive icon lookup)
           # icon_theme = Adwaita
@@ -226,8 +230,8 @@ in
           # Scale larger icons down to this size, set to 0 to disable
           max_icon_size = 64;
 
-          # Paths to default icons (only neccesary when not using recursive icon lookup)
-          icon_path = "/usr/share/icons/Papirus-Dark/16x16/actions:/usr/share/icons/Papirus-Dark/16x16/apps:/usr/share/icons/Papirus-Dark/16x16/devices:/usr/share/icons/Papirus-Dark/16x16/mimetypes:/usr/share/icons/Papirus-Dark/16x16/panel:/usr/share/icons/Papirus-Dark/16x16/places:/usr/share/icons/Papirus-Dark/16x16/status";
+          # Recursive lookup + icon_theme replaces hardcoded /usr/share paths
+          # (which don't exist on NixOS; papirus-icon-theme lands in the profile)
 
           ### History ###
 
@@ -241,10 +245,10 @@ in
           ### Misc/Advanced ###
 
           # dmenu path.
-          dmenu = config.home.homeDirectory + "/.config/rofi/Red-Rofi.rasi -dmenu -p dunst:";
+          dmenu = "${pkgs.rofi}/bin/rofi -dmenu -p dunst";
 
           # Browser for opening urls in context menu.
-          browser = "/usr/bin/xdg-open";
+          browser = "${pkgs.xdg-utils}/bin/xdg-open";
 
           # Always run rule-defined scripts, even if the notification is suppressed
           always_run_script = true;
@@ -260,7 +264,7 @@ in
           # corners.
           # The radius will be automatically lowered if it exceeds half of the
           # notification height to avoid clipping text and/or icons.
-          corner_radius = 12;
+          corner_radius = 14;
 
           # Ignore the dbus closeNotification message.
           # Useful to enforce the timeout set by dunst configuration. Without this
@@ -312,58 +316,60 @@ in
         experimental = {
           per_monitor_dpi = false;
         };
-        # urgency_low = {
-        #   background = "#313244";
-        #   foreground = "#c6d0f5";
-        #   frame_color = "#a6e3a1";
-        #   icon = config.home.homeDirectory + "/.config/dunst/icons/low.svg";
-        #   timeout = 8;
-        # };
-        # urgency_normal = {
-        #   background = "#1e1e2e";
-        #   foreground = "#c6d0f5";
-        #   frame_color = "#89b4fa";
-        #   icon = config.home.homeDirectory + "/.config/dunst/icons/normal.svg";
-        #   timeout = 10;
-        # };
-        # urgency_critical = {
-        #   background = "#1e1e2e";
-        #   foreground = "#f38ba8";
-        #   frame_color = "#e78284";
-        #   icon = config.home.homeDirectory + "/.config/dunst/icons/critical.svg";
-        #   timeout = 0;
-        # };
+        # Urgency tiers: same glass card, frame color carries the severity —
+        # muted surface for low, mauve accent for normal, red (and a touch
+        # more opacity) for critical.
+        urgency_low = {
+          background = "#1e2030E6";
+          foreground = "#a5adcb";
+          frame_color = "#5b6078";
+          timeout = 6;
+        };
+        urgency_normal = {
+          background = "#1e2030E6";
+          foreground = "#cad3f5";
+          frame_color = "#c6a0f6";
+          timeout = 10;
+        };
+        urgency_critical = {
+          background = "#1e2030F2";
+          foreground = "#cad3f5";
+          frame_color = "#ed8796";
+          highlight = "#ed8796";
+          timeout = 0;
+        };
+        # Per-app accents (Macchiato: peach/yellow/mauve/blue/green)
         volume-control = {
           summary = "volctl";
-          format = "\"<span size='large' weight='bold' foreground='#fab387'>󰕾</span> <b>%s</b>\n<span size='small'>%b</span>\"";
-          frame_color = "#fab387";
+          format = "\"<span size='large' weight='bold' foreground='#f5a97f'>󰕾</span> <b>%s</b>\n<span size='small'>%b</span>\"";
+          frame_color = "#f5a97f";
           timeout = 3;
         };
 
         brightness-control = {
           summary = "brightctl";
-          format = "\"<span size='large' weight='bold' foreground='#f9e2af'>󰃟</span> <b>%s</b>\n<span size='small'>%b</span>\"";
-          frame_color = "#f9e2af";
+          format = "\"<span size='large' weight='bold' foreground='#eed49f'>󰃟</span> <b>%s</b>\n<span size='small'>%b</span>\"";
+          frame_color = "#eed49f";
           timeout = 3;
         };
 
         theme-switch = {
           summary = "theme";
-          format = "\"<span size='large' weight='bold' foreground='#cba6f7'>󰐱</span> <b>%s</b>\n<span size='small'>%b</span>\"";
-          frame_color = "#cba6f7";
+          format = "\"<span size='large' weight='bold' foreground='#c6a0f6'>󰐱</span> <b>%s</b>\n<span size='small'>%b</span>\"";
+          frame_color = "#c6a0f6";
           timeout = 5;
         };
 
         network = {
           summary = "*Network*";
-          format = "\"<span size='large' weight='bold' foreground='#89b4fa'>󰖩</span> <b>%s</b>\n<span size='small'>%b</span>\"";
-          frame_color = "#89b4fa";
+          format = "\"<span size='large' weight='bold' foreground='#8aadf4'>󰖩</span> <b>%s</b>\n<span size='small'>%b</span>\"";
+          frame_color = "#8aadf4";
         };
 
         battery = {
           summary = "*Battery*";
-          format = "\"<span size='large' weight='bold' foreground='#a6e3a1'>󰁹</span> <b>%s</b>\n<span size='small'>%b</span>\"";
-          frame_color = "#a6e3a1";
+          format = "\"<span size='large' weight='bold' foreground='#a6da95'>󰁹</span> <b>%s</b>\n<span size='small'>%b</span>\"";
+          frame_color = "#a6da95";
         };
       };
     };

--- a/modules/home/env/default.nix
+++ b/modules/home/env/default.nix
@@ -1,28 +1,44 @@
 # @gitian:security Runtime secret injection — reads SOPS-decrypted files into
 # environment variables at shell init, avoiding Nix store embedding.
 # `sessionVariables` would bake secrets into the store; `initContent` reads them at runtime.
-{ config, lib, ... }:
 {
-  home = {
-    sessionVariables = {
-      EDITOR = "zeditor";
+  config,
+  lib,
+  namespace,
+  ...
+}:
+let
+  cfg = config.${namespace}.env;
+in
+{
+  options.${namespace}.env = {
+    enable = lib.mkEnableOption "env" // {
+      default = true;
     };
   };
 
-  # read secrets into env at runtime to prevent embedding
-  # secrets into the build as sessionVariables does
-  programs.zsh = {
-    initContent = lib.concatStrings [
-      (lib.optionalString (builtins.hasAttr "ai/anthropic/api-key" config.sops.secrets) ''
-        if [ -f "${config.sops.secrets."ai/anthropic/api-key".path}" ]; then
-          export ANTHROPIC_API_KEY=$(cat "${config.sops.secrets."ai/anthropic/api-key".path}")
-        fi
-      '')
-      (lib.optionalString (builtins.hasAttr "localstack/auth-token" config.sops.secrets) ''
-        if [ -f "${config.sops.secrets."localstack/auth-token".path}" ]; then
-          export LOCALSTACK_AUTH_TOKEN=$(cat "${config.sops.secrets."localstack/auth-token".path}")
-        fi
-      '')
-    ];
+  config = lib.mkIf cfg.enable {
+    home = {
+      sessionVariables = {
+        EDITOR = "zeditor";
+      };
+    };
+
+    # read secrets into env at runtime to prevent embedding
+    # secrets into the build as sessionVariables does
+    programs.zsh = {
+      initContent = lib.concatStrings [
+        (lib.optionalString (builtins.hasAttr "ai/anthropic/api-key" config.sops.secrets) ''
+          if [ -f "${config.sops.secrets."ai/anthropic/api-key".path}" ]; then
+            export ANTHROPIC_API_KEY=$(cat "${config.sops.secrets."ai/anthropic/api-key".path}")
+          fi
+        '')
+        (lib.optionalString (builtins.hasAttr "localstack/auth-token" config.sops.secrets) ''
+          if [ -f "${config.sops.secrets."localstack/auth-token".path}" ]; then
+            export LOCALSTACK_AUTH_TOKEN=$(cat "${config.sops.secrets."localstack/auth-token".path}")
+          fi
+        '')
+      ];
+    };
   };
 }

--- a/modules/home/firefox/default.nix
+++ b/modules/home/firefox/default.nix
@@ -8,6 +8,9 @@ in
   };
 
   config = lib.mkIf cfg.enable {
-    programs.firefox.enable = true;
+    programs.firefox = {
+      enable = true;
+      configPath = ".mozilla/firefox";
+    };
   };
 }

--- a/modules/home/fonts/default.nix
+++ b/modules/home/fonts/default.nix
@@ -1,22 +1,36 @@
 {
+  lib,
+  config,
   pkgs,
+  namespace,
   ...
 }:
+let
+  cfg = config.${namespace}.fonts;
+in
 {
-  fonts = {
-    fontconfig = {
-      enable = true;
+  options.${namespace}.fonts = {
+    enable = lib.mkEnableOption "fonts" // {
+      default = true;
+    };
+  };
 
-      defaultFonts = {
-        emoji = [ pkgs.noto-fonts-color-emoji.name ];
-        serif = [ pkgs.nerd-fonts.ubuntu.name ];
-        sansSerif = [ pkgs.nerd-fonts.ubuntu-sans.name ];
-        monospace = [ pkgs.nerd-fonts.intone-mono.name ];
+  config = lib.mkIf cfg.enable {
+    fonts = {
+      fontconfig = {
+        enable = true;
+
+        defaultFonts = {
+          emoji = [ pkgs.noto-fonts-color-emoji.name ];
+          serif = [ pkgs.nerd-fonts.ubuntu.name ];
+          sansSerif = [ pkgs.nerd-fonts.ubuntu-sans.name ];
+          monospace = [ pkgs.nerd-fonts.intone-mono.name ];
+        };
+
+        hinting = "full";
+
+        # subpixelRendering = "rgb";
       };
-
-      hinting = "full";
-
-      # subpixelRendering = "rgb";
     };
   };
 }

--- a/modules/home/git/default.nix
+++ b/modules/home/git/default.nix
@@ -2,37 +2,53 @@
 # to switch between personal and work identities based on the repository path.
 # Commits under `~/projects/personal/` use `arrayofone`; `~/projects/work/` uses `darrenminga`.
 # GPG signing is enforced globally for both commits and tags.
-{ ... }:
 {
-  programs.git = {
-    enable = true;
-    signing.format = "openpgp";
-    includes = [
-      {
-        condition = "gitdir:~/projects/personal/";
-        contents = {
-          "user" = {
-            email = "11287980+arrayofone@users.noreply.github.com";
-            name = "arrayofone";
+  lib,
+  config,
+  namespace,
+  ...
+}:
+let
+  cfg = config.${namespace}.git;
+in
+{
+  options.${namespace}.git = {
+    enable = lib.mkEnableOption "git" // {
+      default = true;
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    programs.git = {
+      enable = true;
+      signing.format = "openpgp";
+      includes = [
+        {
+          condition = "gitdir:~/projects/personal/";
+          contents = {
+            "user" = {
+              email = "11287980+arrayofone@users.noreply.github.com";
+              name = "arrayofone";
+            };
           };
-        };
-      }
-      {
-        condition = "gitdir:~/projects/work/";
-        contents = {
-          "user" = {
-            email = "254569348+darrenminga@users.noreply.github.com";
-            name = "darrenminga";
+        }
+        {
+          condition = "gitdir:~/projects/work/";
+          contents = {
+            "user" = {
+              email = "254569348+darrenminga@users.noreply.github.com";
+              name = "darrenminga";
+            };
           };
+        }
+      ];
+      settings = {
+        "commit" = {
+          gpgsign = true;
         };
-      }
-    ];
-    settings = {
-      "commit" = {
-        gpgsign = true;
-      };
-      "tag" = {
-        gpgsign = true;
+        "tag" = {
+          gpgsign = true;
+        };
       };
     };
   };

--- a/modules/home/hyprland/default.nix
+++ b/modules/home/hyprland/default.nix
@@ -1,6 +1,8 @@
 # @gitian:module Home-manager Hyprland config — comprehensive window manager settings
 # including dwindle/master layouts (golden-ratio splits), animations, keybindings,
 # workspace rules, and special workspaces for calculator/password-manager/notes.
+# Written as a Lua config (configType = "lua") for Hyprland >= 0.56, which dropped
+# hyprlang support on master; settings attrs render as hl.*(...) calls.
 {
   config,
   lib,
@@ -10,6 +12,38 @@
 }:
 let
   cfg = config.${namespace}.hyprland;
+
+  lua = lib.generators.mkLuaInline;
+
+  # hl.bind("MODS + key", <dispatcher>) / hl.bind(..., { mouse/locked/repeating })
+  mkBind = keys: dsp: { _args = [ keys (lua dsp) ]; };
+  mkBindWith = keys: dsp: flags: { _args = [ keys (lua dsp) flags ]; };
+  mkEnv = name: value: { _args = [ name value ]; };
+  mkBezier = name: points: {
+    _args = [
+      name
+      {
+        type = "bezier";
+        inherit points;
+      }
+    ];
+  };
+
+  terminal = "ghostty";
+  browser = "brave";
+  calculator = "qalculate-gtk";
+  fileManager = "thunar";
+  ide = "zeditor";
+  menu = "rofi -show drun -show-icons";
+  mainMod = "SUPER";
+  passman = "proton-pass";
+  obsidianApp = "obsidian";
+  resourceman = "btop";
+
+  ws_1 = "name:term";
+  ws_2 = "name:ide";
+  ws_3 = "name:browser";
+  ws_4 = "name:social";
 in
 {
   options.${namespace}.hyprland = {
@@ -19,6 +53,7 @@ in
   config = lib.mkIf cfg.enable {
     wayland.windowManager.hyprland = {
       enable = true;
+      configType = "lua";
       plugins = [ ];
       xwayland = {
         enable = true;
@@ -28,476 +63,463 @@ in
       portalPackage = null;
 
       settings = {
-        "$terminal" = "foot";
-        "$terminalexec" = "$terminal -e";
-        "$browser" = "brave";
-        "$calculator" = "qalculate-gtk";
-        "$resourceman" = "btop";
-        "$ide" = "zeditor";
-        "$fileManager" = "thunar";
-        "$menu" = "rofi -show drun -show-icons";
-        "$mainMod" = "SUPER";
-        "$passman" = "proton-pass";
-        "$obsidian" = "obsidian";
-
-        "$ws_1" = "name:term";
-        "$ws_2" = "name:ide";
-        "$ws_3" = "name:browser";
-        "$ws_4" = "name:social";
-        "$ws_5" = "5";
-        "$ws_6" = "6";
-        "$ws_7" = "7";
-        "$ws_8" = "8";
-        "$ws_9" = "9";
-        "$ws_10" = "10";
-
         monitor = [
-          ",highres,auto,1"
+          {
+            output = "";
+            mode = "highres";
+            position = "auto";
+            scale = 1;
+          }
         ];
 
         env = [
           # Cursor
-          "XCURSOR_SIZE,24"
-          "XCURSOR_THEME,Bibata-Modern-Ice"
-          "HYPRCURSOR_SIZE,24"
-          "HYPRCURSOR_THEME,Bibata-Modern-Ice"
+          (mkEnv "XCURSOR_SIZE" "24")
+          (mkEnv "XCURSOR_THEME" "Bibata-Modern-Ice")
+          (mkEnv "HYPRCURSOR_SIZE" "24")
+          (mkEnv "HYPRCURSOR_THEME" "Bibata-Modern-Ice")
 
           # Electron/Chromium Wayland
-          "ELECTRON_OZONE_PLATFORM_HINT,auto"
-          "NIXOS_OZONE_WL,1"
+          (mkEnv "ELECTRON_OZONE_PLATFORM_HINT" "auto")
+          (mkEnv "NIXOS_OZONE_WL" "1")
 
           # XDG Desktop
-          "XDG_CURRENT_DESKTOP,Hyprland"
-          "XDG_SESSION_DESKTOP,Hyprland"
-          "XDG_SESSION_TYPE,wayland"
+          (mkEnv "XDG_CURRENT_DESKTOP" "Hyprland")
+          (mkEnv "XDG_SESSION_DESKTOP" "Hyprland")
+          (mkEnv "XDG_SESSION_TYPE" "wayland")
 
           # Qt theming
-          "QT_QPA_PLATFORM,wayland;xcb"
-          "QT_QPA_PLATFORMTHEME,kvantum"
-          "QT_WAYLAND_DISABLE_WINDOWDECORATION,1"
-          "QT_AUTO_SCREEN_SCALE_FACTOR,1"
+          (mkEnv "QT_QPA_PLATFORM" "wayland;xcb")
+          (mkEnv "QT_QPA_PLATFORMTHEME" "kvantum")
+          (mkEnv "QT_WAYLAND_DISABLE_WINDOWDECORATION" "1")
+          (mkEnv "QT_AUTO_SCREEN_SCALE_FACTOR" "1")
 
           # GTK
-          "GDK_BACKEND,wayland,x11,*"
-          "GTK_THEME,Catppuccin-Macchiato-Standard-Mauve-Dark"
+          (mkEnv "GDK_BACKEND" "wayland,x11,*")
+          (mkEnv "GTK_THEME" "Catppuccin-Macchiato-Standard-Mauve-Dark")
         ];
 
-        general = {
-          border_size = 3;
-          gaps_in = 6;
-          gaps_out = 16;
-          float_gaps = 0;
-          gaps_workspaces = 50;
+        # "curve" is in home-manager's default importantPrefixes, so these
+        # render ahead of the hl.animation calls that reference them.
+        curve = [
+          # Smooth and snappy
+          (mkBezier "smoothOut" [ [ 0.36 0 ] [ 0.66 (-0.56) ] ])
+          (mkBezier "smoothIn" [ [ 0.25 1 ] [ 0.5 1 ] ])
+          (mkBezier "overshot" [ [ 0.05 0.9 ] [ 0.1 1.1 ] ])
 
-          # Catppuccin Macchiato gradient border
-          "col.inactive_border" = lib.mkDefault "rgba(363a4f88)";
-          "col.active_border" = lib.mkDefault "rgba(c6a0f6ff) rgba(8bd5caff) rgba(8aadf4ff) 45deg";
-          "col.nogroup_border" = lib.mkDefault "rgba(494d6488)";
-          "col.nogroup_border_active" = lib.mkDefault "rgba(ed8796ff)";
+          # Fluent design inspired
+          (mkBezier "fluent_decel" [ [ 0.1 1 ] [ 0 1 ] ])
+          (mkBezier "easeOutCirc" [ [ 0 0.55 ] [ 0.45 1 ] ])
+          (mkBezier "easeOutCubic" [ [ 0.33 1 ] [ 0.68 1 ] ])
+          (mkBezier "easeInOutQuart" [ [ 0.76 0 ] [ 0.24 1 ] ])
 
-          layout = "dwindle";
-          no_focus_fallback = false;
-          resize_on_border = true;
-          extend_border_grab_area = 20;
-          hover_icon_on_border = true;
-          allow_tearing = false;
-          resize_corner = 0;
+          # Elastic and bouncy
+          (mkBezier "elastic" [ [ 0.68 (-0.6) ] [ 0.32 1.6 ] ])
+          (mkBezier "bounce" [ [ 0.175 0.885 ] [ 0.32 1.275 ] ])
 
-          snap = {
+          # Utility
+          (mkBezier "linear" [ [ 0 0 ] [ 1 1 ] ])
+          (mkBezier "quick" [ [ 0.15 0 ] [ 0.1 1 ] ])
+        ];
+
+        animation = [
+          { leaf = "global"; enabled = true; speed = 6; bezier = "default"; }
+
+          # Border animations - rotating gradient
+          { leaf = "border"; enabled = true; speed = 8; bezier = "fluent_decel"; }
+          { leaf = "borderangle"; enabled = true; speed = 100; bezier = "linear"; style = "loop"; }
+
+          # Window animations
+          { leaf = "windows"; enabled = true; speed = 5; bezier = "overshot"; style = "popin 80%"; }
+          { leaf = "windowsIn"; enabled = true; speed = 5; bezier = "bounce"; style = "popin 80%"; }
+          { leaf = "windowsOut"; enabled = true; speed = 4; bezier = "smoothOut"; style = "popin 80%"; }
+          { leaf = "windowsMove"; enabled = true; speed = 5; bezier = "overshot"; style = "slide"; }
+
+          # Fade animations
+          { leaf = "fadeIn"; enabled = true; speed = 4; bezier = "smoothIn"; }
+          { leaf = "fadeOut"; enabled = true; speed = 4; bezier = "smoothOut"; }
+          { leaf = "fade"; enabled = true; speed = 6; bezier = "smoothIn"; }
+          { leaf = "fadeDim"; enabled = true; speed = 6; bezier = "smoothIn"; }
+          { leaf = "fadeShadow"; enabled = true; speed = 6; bezier = "smoothIn"; }
+
+          # Layer animations (rofi, waybar, etc.)
+          { leaf = "layers"; enabled = true; speed = 4; bezier = "smoothIn"; style = "fade"; }
+          { leaf = "layersIn"; enabled = true; speed = 4; bezier = "bounce"; style = "slide"; }
+          { leaf = "layersOut"; enabled = true; speed = 3; bezier = "smoothOut"; style = "slide"; }
+
+          # Workspace animations
+          { leaf = "workspaces"; enabled = true; speed = 5; bezier = "overshot"; style = "slide"; }
+          { leaf = "workspacesIn"; enabled = true; speed = 5; bezier = "bounce"; style = "slidefade 20%"; }
+          { leaf = "workspacesOut"; enabled = true; speed = 5; bezier = "smoothOut"; style = "slidefade 20%"; }
+          { leaf = "specialWorkspace"; enabled = true; speed = 4; bezier = "bounce"; style = "slidevert"; }
+        ];
+
+        config = {
+          general = {
+            border_size = 3;
+            gaps_in = 6;
+            gaps_out = 16;
+            float_gaps = 0;
+            gaps_workspaces = 50;
+
+            # Catppuccin Macchiato gradient border
+            col = {
+              inactive_border = lib.mkDefault "rgba(363a4f88)";
+              active_border = lib.mkDefault {
+                colors = [
+                  "rgba(c6a0f6ff)"
+                  "rgba(8bd5caff)"
+                  "rgba(8aadf4ff)"
+                ];
+                angle = 45;
+              };
+              nogroup_border = lib.mkDefault "rgba(494d6488)";
+              nogroup_border_active = lib.mkDefault "rgba(ed8796ff)";
+            };
+
+            layout = "dwindle";
+            no_focus_fallback = false;
+            resize_on_border = true;
+            extend_border_grab_area = 20;
+            hover_icon_on_border = true;
+            allow_tearing = false;
+            resize_corner = 0;
+
+            snap = {
+              enabled = true;
+              window_gap = 15;
+              monitor_gap = 20;
+              border_overlap = true;
+              respect_gaps = true;
+            };
+          };
+
+          decoration = {
+            rounding = 14;
+            rounding_power = 2.2;
+            active_opacity = 1.0;
+            inactive_opacity = 0.92;
+            fullscreen_opacity = 1.0;
+            dim_inactive = true;
+            dim_strength = 0.12;
+            dim_special = 0.3;
+            dim_around = 0.5;
+            screen_shader = "";
+            border_part_of_window = true;
+
+            blur = {
+              enabled = true;
+              size = 12;
+              passes = 4;
+              ignore_opacity = true;
+              new_optimizations = true;
+              xray = false;
+              noise = 0.02;
+              contrast = 1.05;
+              brightness = 0.95;
+              vibrancy = 0.3;
+              vibrancy_darkness = 0.3;
+              special = true;
+              popups = true;
+              popups_ignorealpha = 0.5;
+              input_methods = true;
+              input_methods_ignorealpha = 0.5;
+            };
+
+            shadow = {
+              enabled = true;
+              range = 20;
+              render_power = 4;
+              sharp = false;
+              color = lib.mkDefault "rgba(1a1a2ecc)";
+              color_inactive = lib.mkDefault "rgba(1a1a2e99)";
+              offset = "0 12";
+              scale = 0.95;
+            };
+          };
+
+          animations = {
             enabled = true;
-            window_gap = 15;
-            monitor_gap = 20;
-            border_overlap = true;
-            respect_gaps = true;
-          };
-        };
-
-        decoration = {
-          rounding = 14;
-          rounding_power = 2.2;
-          active_opacity = 1.0;
-          inactive_opacity = 0.92;
-          fullscreen_opacity = 1.0;
-          dim_inactive = true;
-          dim_strength = 0.12;
-          dim_special = 0.3;
-          dim_around = 0.5;
-          screen_shader = "";
-          border_part_of_window = true;
-
-          blur = {
-            enabled = true;
-            size = 12;
-            passes = 4;
-            ignore_opacity = true;
-            new_optimizations = true;
-            xray = false;
-            noise = 0.02;
-            contrast = 1.05;
-            brightness = 0.95;
-            vibrancy = 0.3;
-            vibrancy_darkness = 0.3;
-            special = true;
-            popups = true;
-            popups_ignorealpha = 0.5;
-            input_methods = true;
-            input_methods_ignorealpha = 0.5;
+            workspace_wraparound = false;
           };
 
-          shadow = {
-            enabled = true;
-            range = 20;
-            render_power = 4;
-            sharp = false;
-            ignore_window = true;
-            color = lib.mkDefault "rgba(1a1a2ecc)";
-            color_inactive = lib.mkDefault "rgba(1a1a2e99)";
-            offset = "0 12";
-            scale = 0.95;
-          };
-        };
-
-        animations = {
-          enabled = true;
-          workspace_wraparound = false;
-
-          bezier = [
-            # Smooth and snappy
-            "smoothOut, 0.36, 0, 0.66, -0.56"
-            "smoothIn, 0.25, 1, 0.5, 1"
-            "overshot, 0.05, 0.9, 0.1, 1.1"
-
-            # Fluent design inspired
-            "fluent_decel, 0.1, 1, 0, 1"
-            "easeOutCirc, 0, 0.55, 0.45, 1"
-            "easeOutCubic, 0.33, 1, 0.68, 1"
-            "easeInOutQuart, 0.76, 0, 0.24, 1"
-
-            # Elastic and bouncy
-            "elastic, 0.68, -0.6, 0.32, 1.6"
-            "bounce, 0.175, 0.885, 0.32, 1.275"
-
-            # Utility
-            "linear, 0, 0, 1, 1"
-            "quick, 0.15, 0, 0.1, 1"
-          ];
-
-          animation = [
-            "global, 1, 6, default"
-
-            # Border animations - rotating gradient
-            "border, 1, 8, fluent_decel"
-            "borderangle, 1, 100, linear, loop"
-
-            # Window animations
-            "windows, 1, 5, overshot, popin 80%"
-            "windowsIn, 1, 5, bounce, popin 80%"
-            "windowsOut, 1, 4, smoothOut, popin 80%"
-            "windowsMove, 1, 5, overshot, slide"
-
-            # Fade animations
-            "fadeIn, 1, 4, smoothIn"
-            "fadeOut, 1, 4, smoothOut"
-            "fade, 1, 6, smoothIn"
-            "fadeDim, 1, 6, smoothIn"
-            "fadeShadow, 1, 6, smoothIn"
-
-            # Layer animations (rofi, waybar, etc.)
-            "layers, 1, 4, smoothIn, fade"
-            "layersIn, 1, 4, bounce, slide"
-            "layersOut, 1, 3, smoothOut, slide"
-
-            # Workspace animations
-            "workspaces, 1, 5, overshot, slide"
-            "workspacesIn, 1, 5, bounce, slidefade 20%"
-            "workspacesOut, 1, 5, smoothOut, slidefade 20%"
-            "specialWorkspace, 1, 4, bounce, slidevert"
-          ];
-        };
-
-        input = {
-          kb_model = "";
-          kb_layout = "us";
-          kb_variant = "";
-          kb_options = "";
-          kb_rules = "";
-          kb_file = "";
-          numlock_by_default = false;
-          resolve_binds_by_sym = false;
-          repeat_rate = 25;
-          repeat_delay = 600;
-          sensitivity = 0.0;
-          accel_profile = "";
-          force_no_accel = false;
-          left_handed = false;
-          scroll_points = "";
-          scroll_method = "";
-          scroll_button = 0;
-          scroll_button_lock = false;
-          scroll_factor = 1.0;
-          natural_scroll = false;
-          follow_mouse = 1;
-          follow_mouse_threshold = 0.0;
-          focus_on_close = 0;
-          mouse_refocus = true;
-          float_switch_override_focus = 1;
-          special_fallthrough = false;
-          off_window_axis_events = 1;
-          emulate_discrete_scroll = 1;
-
-          touchpad = {
-            disable_while_typing = true;
-            natural_scroll = false;
-            scroll_factor = 1.0;
-            middle_button_emulation = false;
-            tap_button_map = "";
-            clickfinger_behavior = false;
-            tap-to-click = true;
-            drag_lock = 2;
-            tap-and-drag = true;
-            flip_x = false;
-            flip_y = false;
-            drag_3fg = 0;
-          };
-
-          touchdevice = {
-            transform = -1;
-            output = "[[Auto]]";
-            enabled = true;
-          };
-
-          tablet = {
-            transform = -1;
-            output = "";
-            region_position = "0 0";
-            absolute_region_position = false;
-            region_size = "0 0";
-            relative_input = false;
+          input = {
+            kb_model = "";
+            kb_layout = "us";
+            kb_variant = "";
+            kb_options = "";
+            kb_rules = "";
+            kb_file = "";
+            numlock_by_default = false;
+            resolve_binds_by_sym = false;
+            repeat_rate = 25;
+            repeat_delay = 600;
+            sensitivity = 0.0;
+            accel_profile = "";
+            force_no_accel = false;
             left_handed = false;
-            active_area_size = "0 0";
-            active_area_position = "0 0";
+            scroll_points = "";
+            scroll_method = "";
+            scroll_button = 0;
+            scroll_button_lock = false;
+            scroll_factor = 1.0;
+            natural_scroll = false;
+            follow_mouse = 1;
+            follow_mouse_threshold = 0.0;
+            focus_on_close = 0;
+            mouse_refocus = true;
+            float_switch_override_focus = 1;
+            special_fallthrough = false;
+            off_window_axis_events = 1;
+            emulate_discrete_scroll = 1;
+
+            touchpad = {
+              disable_while_typing = true;
+              natural_scroll = false;
+              scroll_factor = 1.0;
+              middle_button_emulation = false;
+              tap_button_map = "";
+              clickfinger_behavior = false;
+              tap_to_click = true;
+              drag_lock = 2;
+              tap_and_drag = true;
+              flip_x = false;
+              flip_y = false;
+              drag_3fg = 0;
+            };
+
+            touchdevice = {
+              transform = -1;
+              output = "[[Auto]]";
+              enabled = true;
+            };
+
+            tablet = {
+              transform = -1;
+              output = "";
+              region_position = "0 0";
+              absolute_region_position = false;
+              region_size = "0 0";
+              relative_input = false;
+              left_handed = false;
+              active_area_size = "0 0";
+              active_area_position = "0 0";
+            };
           };
-        };
 
-        gestures = {
-          # workspace_swipe = false;
-          # workspace_swipe_fingers = 3;
-          # workspace_swipe_min_fingers = false;
-          workspace_swipe_distance = 300;
-          workspace_swipe_touch = false;
-          workspace_swipe_invert = true;
-          workspace_swipe_touch_invert = false;
-          workspace_swipe_min_speed_to_force = 30;
-          workspace_swipe_cancel_ratio = 0.5;
-          workspace_swipe_create_new = true;
-          workspace_swipe_direction_lock = true;
-          workspace_swipe_direction_lock_threshold = 10;
-          workspace_swipe_forever = false;
-          workspace_swipe_use_r = false;
-        };
+          gestures = {
+            workspace_swipe_distance = 300;
+            workspace_swipe_touch = false;
+            workspace_swipe_invert = true;
+            workspace_swipe_touch_invert = false;
+            workspace_swipe_min_speed_to_force = 30;
+            workspace_swipe_cancel_ratio = 0.5;
+            workspace_swipe_create_new = true;
+            workspace_swipe_direction_lock = true;
+            workspace_swipe_direction_lock_threshold = 10;
+            workspace_swipe_forever = false;
+            workspace_swipe_use_r = false;
+          };
 
-        group = {
-          auto_group = true;
-          insert_after_current = true;
-          focus_removed_window = true;
-          drag_into_group = 1;
-          merge_groups_on_drag = true;
-          merge_groups_on_groupbar = true;
-          merge_floated_into_tiled_on_groupbar = false;
-          group_on_movetoworkspace = false;
+          group = {
+            auto_group = true;
+            insert_after_current = true;
+            focus_removed_window = true;
+            drag_into_group = 1;
+            merge_groups_on_drag = true;
+            merge_groups_on_groupbar = true;
+            merge_floated_into_tiled_on_groupbar = false;
+            group_on_movetoworkspace = false;
 
-          # Catppuccin Macchiato group colors
-          "col.border_active" = lib.mkDefault "rgba(c6a0f6ff)";
-          "col.border_inactive" = lib.mkDefault "rgba(494d6488)";
-          "col.border_locked_active" = lib.mkDefault "rgba(ed8796ff)";
-          "col.border_locked_inactive" = lib.mkDefault "rgba(5b607888)";
+            # Catppuccin Macchiato group colors
+            col = {
+              border_active = lib.mkDefault "rgba(c6a0f6ff)";
+              border_inactive = lib.mkDefault "rgba(494d6488)";
+              border_locked_active = lib.mkDefault "rgba(ed8796ff)";
+              border_locked_inactive = lib.mkDefault "rgba(5b607888)";
+            };
 
-          groupbar = {
+            groupbar = {
+              enabled = true;
+              font_family = "Ubuntu Sans";
+              font_size = 11;
+              font_weight_active = "bold";
+              font_weight_inactive = "normal";
+              gradients = true;
+              height = 22;
+              indicator_gap = 2;
+              indicator_height = 4;
+              stacked = false;
+              priority = 3;
+              render_titles = true;
+              text_offset = 0;
+              scrolling = true;
+              rounding = 10;
+              gradient_rounding = 8;
+              round_only_edges = true;
+              gradient_round_only_edges = true;
+              # Catppuccin Macchiato text colors
+              text_color = lib.mkDefault "rgba(cad3f5ff)";
+              text_color_inactive = lib.mkDefault "rgba(a5adcbcc)";
+              text_color_locked_active = lib.mkDefault "rgba(ed8796ff)";
+              text_color_locked_inactive = lib.mkDefault "rgba(ee99a0cc)";
+              # Catppuccin Macchiato bar colors
+              col = {
+                active = lib.mkDefault "rgba(c6a0f6cc)";
+                inactive = lib.mkDefault "rgba(363a4fcc)";
+                locked_active = lib.mkDefault "rgba(ed8796cc)";
+                locked_inactive = lib.mkDefault "rgba(494d64cc)";
+              };
+              gaps_in = 3;
+              gaps_out = 3;
+              keep_upper_gap = true;
+            };
+          };
+
+          misc = {
+            disable_hyprland_logo = true;
+            disable_splash_rendering = true;
+            col = {
+              splash = "rgba(c6a0f6ff)";
+            };
+            font_family = lib.mkDefault "Ubuntu";
+            splash_font_family = "Ubuntu Sans";
+            force_default_wallpaper = 0;
+            # vfr = true;
+            vrr = 1;
+            mouse_move_enables_dpms = false;
+            key_press_enables_dpms = false;
+            always_follow_on_dnd = true;
+            layers_hog_keyboard_focus = true;
+            animate_manual_resizes = true;
+            animate_mouse_windowdragging = true;
+            disable_autoreload = false;
+            enable_swallow = false;
+            swallow_regex = "";
+            swallow_exception_regex = "";
+            focus_on_activate = false;
+            mouse_move_focuses_monitor = true;
+            allow_session_lock_restore = false;
+            background_color = lib.mkDefault "0x24273a";
+            close_special_on_empty = true;
+            exit_window_retains_fullscreen = false;
+            initial_workspace_tracking = 1;
+            middle_click_paste = true;
+            render_unfocused_fps = 15;
+            disable_xdg_env_checks = false;
+            lockdead_screen_delay = 1000;
+            enable_anr_dialog = true;
+            anr_missed_pings = 1;
+          };
+
+          binds = {
+            pass_mouse_when_bound = false;
+            scroll_event_delay = 300;
+            workspace_back_and_forth = false;
+            hide_special_on_workspace_change = false;
+            allow_workspace_cycles = false;
+            workspace_center_on = 0;
+            focus_preferred_method = 0;
+            ignore_group_lock = false;
+            movefocus_cycles_fullscreen = false;
+            movefocus_cycles_groupfirst = false;
+            disable_keybind_grabbing = false;
+            window_direction_monitor_fallback = true;
+            allow_pin_fullscreen = false;
+            drag_threshold = 0;
+          };
+
+          xwayland = {
             enabled = true;
-            font_family = "Ubuntu Sans";
-            font_size = 11;
-            font_weight_active = "bold";
-            font_weight_inactive = "normal";
-            gradients = true;
-            height = 22;
-            indicator_gap = 2;
-            indicator_height = 4;
-            stacked = false;
-            priority = 3;
-            render_titles = true;
-            text_offset = 0;
-            scrolling = true;
-            rounding = 10;
-            gradient_rounding = 8;
-            round_only_edges = true;
-            gradient_round_only_edges = true;
-            # Catppuccin Macchiato text colors
-            text_color = lib.mkDefault "rgba(cad3f5ff)";
-            text_color_inactive = lib.mkDefault "rgba(a5adcbcc)";
-            text_color_locked_active = lib.mkDefault "rgba(ed8796ff)";
-            text_color_locked_inactive = lib.mkDefault "rgba(ee99a0cc)";
-            # Catppuccin Macchiato bar colors
-            "col.active" = lib.mkDefault "rgba(c6a0f6cc)";
-            "col.inactive" = lib.mkDefault "rgba(363a4fcc)";
-            "col.locked_active" = lib.mkDefault "rgba(ed8796cc)";
-            "col.locked_inactive" = lib.mkDefault "rgba(494d64cc)";
-            gaps_in = 3;
-            gaps_out = 3;
-            keep_upper_gap = true;
+            use_nearest_neighbor = true;
+            force_zero_scaling = false;
+            create_abstract_socket = false;
           };
-        };
 
-        misc = {
-          disable_hyprland_logo = true;
-          disable_splash_rendering = true;
-          "col.splash" = "rgba(c6a0f6ff)";
-          font_family = lib.mkDefault "Ubuntu";
-          splash_font_family = "Ubuntu Sans";
-          force_default_wallpaper = 0;
-          vfr = true;
-          vrr = 1;
-          mouse_move_enables_dpms = false;
-          key_press_enables_dpms = false;
-          always_follow_on_dnd = true;
-          layers_hog_keyboard_focus = true;
-          animate_manual_resizes = true;
-          animate_mouse_windowdragging = true;
-          disable_autoreload = false;
-          enable_swallow = false;
-          swallow_regex = "";
-          swallow_exception_regex = "";
-          focus_on_activate = false;
-          mouse_move_focuses_monitor = true;
-          allow_session_lock_restore = false;
-          # session_lock_xray = false; # does not exist. Bug in documentation?
-          background_color = lib.mkDefault "0x24273a";
-          close_special_on_empty = true;
-          exit_window_retains_fullscreen = false;
-          initial_workspace_tracking = 1;
-          middle_click_paste = true;
-          render_unfocused_fps = 15;
-          disable_xdg_env_checks = false;
-          lockdead_screen_delay = 1000;
-          enable_anr_dialog = true;
-          anr_missed_pings = 1;
-        };
+          opengl = {
+            nvidia_anti_flicker = false;
+          };
 
-        binds = {
-          pass_mouse_when_bound = false;
-          scroll_event_delay = 300;
-          workspace_back_and_forth = false;
-          hide_special_on_workspace_change = false;
-          allow_workspace_cycles = false;
-          workspace_center_on = 0;
-          focus_preferred_method = 0;
-          ignore_group_lock = false;
-          movefocus_cycles_fullscreen = false;
-          movefocus_cycles_groupfirst = false;
-          disable_keybind_grabbing = false;
-          window_direction_monitor_fallback = true;
-          allow_pin_fullscreen = false;
-          drag_threshold = 0;
-        };
+          render = {
+            direct_scanout = 0;
+            expand_undersized_textures = true;
+            xp_mode = false;
+            ctm_animation = 2;
+            cm_enabled = true;
+            send_content_type = true;
+            cm_auto_hdr = 1;
+            new_render_scheduling = false;
+          };
 
-        xwayland = {
-          enabled = true;
-          use_nearest_neighbor = true;
-          force_zero_scaling = false;
-          create_abstract_socket = false;
-        };
+          cursor = {
+            sync_gsettings_theme = false;
+            no_hardware_cursors = 2;
+            no_break_fs_vrr = 2;
+            min_refresh_rate = 24;
+            hotspot_padding = 1;
+            inactive_timeout = 0;
+            no_warps = false;
+            persistent_warps = false;
+            warp_on_change_workspace = 0;
+            warp_on_toggle_special = 0;
+            default_monitor = "[[EMPTY]]";
+            zoom_factor = 1.0;
+            zoom_rigid = false;
+            enable_hyprcursor = true;
+            hide_on_key_press = false;
+            hide_on_touch = true;
+            use_cpu_buffer = 2;
+            warp_back_after_non_mouse_input = false;
+          };
 
-        opengl = {
-          nvidia_anti_flicker = false;
-        };
+          ecosystem = {
+            no_update_news = false;
+            no_donation_nag = false;
+            enforce_permissions = false;
+          };
 
-        render = {
-          direct_scanout = 0;
-          expand_undersized_textures = true;
-          xp_mode = false;
-          ctm_animation = 2;
-          cm_fs_passthrough = 2;
-          cm_enabled = true;
-          send_content_type = true;
-          cm_auto_hdr = 1;
-          new_render_scheduling = false;
-        };
+          debug = {
+            overlay = false;
+            damage_blink = false;
+            disable_logs = true;
+            disable_time = true;
+            damage_tracking = 2;
+            enable_stdout_logs = false;
+            manual_crash = 0;
+            suppress_errors = false;
+            disable_scale_checks = false;
+            error_limit = 5;
+            error_position = 0;
+            colored_stdout_logs = true;
+            pass = false;
+            full_cm_proto = false;
+          };
 
-        cursor = {
-          sync_gsettings_theme = false;
-          no_hardware_cursors = 2;
-          no_break_fs_vrr = 2;
-          min_refresh_rate = 24;
-          hotspot_padding = 1;
-          inactive_timeout = 0;
-          no_warps = false;
-          persistent_warps = false;
-          warp_on_change_workspace = 0;
-          warp_on_toggle_special = 0;
-          default_monitor = "[[EMPTY]]";
-          zoom_factor = 1.0;
-          zoom_rigid = false;
-          enable_hyprcursor = true;
-          hide_on_key_press = false;
-          hide_on_touch = true;
-          use_cpu_buffer = 2;
-          warp_back_after_non_mouse_input = false;
-        };
+          dwindle = {
+            force_split = 2;
+            preserve_split = true;
+            smart_split = true;
+            smart_resizing = true;
+            permanent_direction_override = false;
+            special_scale_factor = 0.8;
+            split_width_multiplier = 1.0;
+            use_active_for_splits = true;
+            default_split_ratio = 1.618; # Golden ratio for elegant proportions
+            split_bias = 0;
+            precise_mouse_move = true;
+          };
 
-        ecosystem = {
-          no_update_news = false;
-          no_donation_nag = false;
-          enforce_permissions = false;
-        };
-
-        experimental = {
-          # xx_color_management_v4 = false;
-        };
-
-        debug = {
-          overlay = false;
-          damage_blink = false;
-          disable_logs = true;
-          disable_time = true;
-          damage_tracking = 2;
-          enable_stdout_logs = false;
-          manual_crash = 0;
-          suppress_errors = false;
-          # watchdog_timeout = 5;
-          disable_scale_checks = false;
-          error_limit = 5;
-          error_position = 0;
-          colored_stdout_logs = true;
-          pass = false;
-          full_cm_proto = false;
-        };
-
-        dwindle = {
-          pseudotile = true;
-          force_split = 2;
-          preserve_split = true;
-          smart_split = true;
-          smart_resizing = true;
-          permanent_direction_override = false;
-          special_scale_factor = 0.8;
-          split_width_multiplier = 1.0;
-          use_active_for_splits = true;
-          default_split_ratio = 1.618; # Golden ratio for elegant proportions
-          split_bias = 0;
-          precise_mouse_move = true;
-          single_window_aspect_ratio = "16 10";
-          single_window_aspect_ratio_tolerance = 0.15;
-        };
-
-        master = {
-          allow_small_split = true;
-          new_status = "master";
-          new_on_active = "after";
-          new_on_top = false;
-          orientation = "left";
-          smart_resizing = true;
-          drop_at_cursor = true;
-          mfact = 0.618; # Golden ratio for master area
-          special_scale_factor = 0.8;
+          master = {
+            allow_small_split = true;
+            new_status = "master";
+            new_on_active = "after";
+            new_on_top = false;
+            orientation = "left";
+            smart_resizing = true;
+            drop_at_cursor = true;
+            mfact = 0.618; # Golden ratio for master area
+            special_scale_factor = 0.8;
+          };
         };
 
         device = {
@@ -506,216 +528,177 @@ in
         };
 
         bind = [
-          "$mainMod, space, exec, $menu"
-          "$mainMod, T, exec, $terminal"
-          "$mainMod, Q, killactive,"
-          "$mainMod, F, togglefloating,"
-          "$mainMod, E, exec, $fileManager"
-          "$mainMod, S, exec, shotman -c region -C"
-          "$mainMod, D, exec, GDK_BACKEND=x11 dbeaver"
+          (mkBind "${mainMod} + space" ''hl.dsp.exec_cmd("${menu}")'')
+          (mkBind "${mainMod} + T" ''hl.dsp.exec_cmd("${terminal}")'')
+          (mkBind "${mainMod} + Q" ''hl.dsp.window.close()'')
+          (mkBind "${mainMod} + F" ''hl.dsp.window.float({ action = "toggle" })'')
+          (mkBind "${mainMod} + E" ''hl.dsp.exec_cmd("${fileManager}")'')
+          (mkBind "${mainMod} + S" ''hl.dsp.exec_cmd("shotman -c region -C")'')
+          (mkBind "${mainMod} + D" ''hl.dsp.exec_cmd("GDK_BACKEND=x11 dbeaver")'')
 
-          "$mainMod, M, exit,"
-          "$mainMod, P, pseudo,"
-          "$mainMod, J, togglesplit,"
-          "$mainMod, L, exec, ${pkgs.hyprlock}/bin/hyprlock"
+          (mkBind "${mainMod} + M" ''hl.dsp.exit()'')
+          (mkBind "${mainMod} + P" ''hl.dsp.window.pseudo()'')
+          (mkBind "${mainMod} + L" ''hl.dsp.exec_cmd("${pkgs.hyprlock}/bin/hyprlock")'')
 
-          "$mainMod ALT, M, exec, reboot"
+          (mkBind "${mainMod} + ALT + M" ''hl.dsp.exec_cmd("reboot")'')
 
-          "$mainMod, left, movefocus, l"
-          "$mainMod, right, movefocus, r"
-          "$mainMod, up, movefocus, u"
-          "$mainMod, down, movefocus, d"
+          (mkBind "${mainMod} + left" ''hl.dsp.focus({ direction = "left" })'')
+          (mkBind "${mainMod} + right" ''hl.dsp.focus({ direction = "right" })'')
+          (mkBind "${mainMod} + up" ''hl.dsp.focus({ direction = "up" })'')
+          (mkBind "${mainMod} + down" ''hl.dsp.focus({ direction = "down" })'')
 
-          "$mainMod, 1, workspace, $ws_1"
-          "$mainMod, 2, workspace, $ws_2"
-          "$mainMod, 3, workspace, $ws_3"
-          "$mainMod, 4, workspace, $ws_4"
-          "$mainMod, 5, workspace, 5"
-          "$mainMod, 6, workspace, 6"
-          "$mainMod, 7, workspace, 7"
-          "$mainMod, 8, workspace, 8"
-          "$mainMod, 9, workspace, 9"
-          "$mainMod, 0, workspace, 10"
+          (mkBind "${mainMod} + 1" ''hl.dsp.focus({ workspace = "${ws_1}" })'')
+          (mkBind "${mainMod} + 2" ''hl.dsp.focus({ workspace = "${ws_2}" })'')
+          (mkBind "${mainMod} + 3" ''hl.dsp.focus({ workspace = "${ws_3}" })'')
+          (mkBind "${mainMod} + 4" ''hl.dsp.focus({ workspace = "${ws_4}" })'')
+          (mkBind "${mainMod} + 5" ''hl.dsp.focus({ workspace = 5 })'')
+          (mkBind "${mainMod} + 6" ''hl.dsp.focus({ workspace = 6 })'')
+          (mkBind "${mainMod} + 7" ''hl.dsp.focus({ workspace = 7 })'')
+          (mkBind "${mainMod} + 8" ''hl.dsp.focus({ workspace = 8 })'')
+          (mkBind "${mainMod} + 9" ''hl.dsp.focus({ workspace = 9 })'')
+          (mkBind "${mainMod} + 0" ''hl.dsp.focus({ workspace = 10 })'')
 
-          "$mainMod SHIFT, 1, movetoworkspace, $ws_1"
-          "$mainMod SHIFT, 2, movetoworkspace, $ws_2"
-          "$mainMod SHIFT, 3, movetoworkspace, $ws_3"
-          "$mainMod SHIFT, 4, movetoworkspace, $ws_4"
-          "$mainMod SHIFT, 5, movetoworkspace, 5"
-          "$mainMod SHIFT, 6, movetoworkspace, 6"
-          "$mainMod SHIFT, 7, movetoworkspace, 7"
-          "$mainMod SHIFT, 8, movetoworkspace, 8"
-          "$mainMod SHIFT, 9, movetoworkspace, 9"
-          "$mainMod SHIFT, 0, movetoworkspace, 10"
+          (mkBind "${mainMod} + SHIFT + 1" ''hl.dsp.window.move({ workspace = "${ws_1}" })'')
+          (mkBind "${mainMod} + SHIFT + 2" ''hl.dsp.window.move({ workspace = "${ws_2}" })'')
+          (mkBind "${mainMod} + SHIFT + 3" ''hl.dsp.window.move({ workspace = "${ws_3}" })'')
+          (mkBind "${mainMod} + SHIFT + 4" ''hl.dsp.window.move({ workspace = "${ws_4}" })'')
+          (mkBind "${mainMod} + SHIFT + 5" ''hl.dsp.window.move({ workspace = 5 })'')
+          (mkBind "${mainMod} + SHIFT + 6" ''hl.dsp.window.move({ workspace = 6 })'')
+          (mkBind "${mainMod} + SHIFT + 7" ''hl.dsp.window.move({ workspace = 7 })'')
+          (mkBind "${mainMod} + SHIFT + 8" ''hl.dsp.window.move({ workspace = 8 })'')
+          (mkBind "${mainMod} + SHIFT + 9" ''hl.dsp.window.move({ workspace = 9 })'')
+          (mkBind "${mainMod} + SHIFT + 0" ''hl.dsp.window.move({ workspace = 10 })'')
 
-          "$mainMod SHIFT, Q, exec, pgrep $calculator && hyprctl dispatch togglespecialworkspace special:calculator || $calculator &"
-          "$mainMod SHIFT, P, exec, hyprctl dispatch togglespecialworkspace special:passman && $passman &"
-          "$mainMod SHIFT, R, exec, hyprctl clients -j | jq  '.[].title' | grep \"$resourceman\" && hyprctl dispatch togglespecialworkspace special:resourceman || $terminalexec $resourceman"
-          "$mainMod SHIFT, O, exec, hyprctl clients -j | jq  '.[].class' | grep \"obsidian\" && hyprctl dispatch togglespecialworkspace special:obsidian || $obsidian"
+          # Special workspaces: on_created_empty workspace rules spawn the app,
+          # so a plain toggle replaces the old pgrep/hyprctl shell dance
+          (mkBind "${mainMod} + SHIFT + Q" ''hl.dsp.workspace.toggle_special("calculator")'')
+          (mkBind "${mainMod} + SHIFT + P" ''hl.dsp.workspace.toggle_special("passman")'')
+          (mkBind "${mainMod} + SHIFT + R" ''hl.dsp.workspace.toggle_special("resourceman")'')
+          (mkBind "${mainMod} + SHIFT + O" ''hl.dsp.workspace.toggle_special("obsidian")'')
 
-          # "$mainMod, S, togglespecialworkspace, magic"
-          # "$mainMod SHIFT, S, movetoworkspace, special:magic"
+          (mkBind "${mainMod} + mouse_down" ''hl.dsp.focus({ workspace = "e+1" })'')
+          (mkBind "${mainMod} + mouse_up" ''hl.dsp.focus({ workspace = "e-1" })'')
 
-          "$mainMod, mouse_down, workspace, e+1"
-          "$mainMod, mouse_up, workspace, e-1"
+          # Mouse binds (previously bindm)
+          (mkBindWith "${mainMod} + mouse:272" ''hl.dsp.window.drag()'' { mouse = true; })
+          (mkBindWith "${mainMod} + mouse:273" ''hl.dsp.window.resize()'' { mouse = true; })
+
+          # Media/brightness keys (previously bindel)
+          (mkBindWith "XF86AudioRaiseVolume" ''hl.dsp.exec_cmd("wpctl set-volume @DEFAULT_AUDIO_SINK@ 5%+")'' {
+            locked = true;
+            repeating = true;
+          })
+          (mkBindWith "XF86AudioLowerVolume" ''hl.dsp.exec_cmd("wpctl set-volume @DEFAULT_AUDIO_SINK@ 5%-")'' {
+            locked = true;
+            repeating = true;
+          })
+          (mkBindWith "XF86AudioMute" ''hl.dsp.exec_cmd("wpctl set-mute @DEFAULT_AUDIO_SINK@ toggle")'' {
+            locked = true;
+            repeating = true;
+          })
+          (mkBindWith "XF86AudioMicMute" ''hl.dsp.exec_cmd("wpctl set-mute @DEFAULT_AUDIO_SOURCE@ toggle")'' {
+            locked = true;
+            repeating = true;
+          })
+          (mkBindWith "XF86MonBrightnessUp" ''hl.dsp.exec_cmd("brightnessctl s 10%+")'' {
+            locked = true;
+            repeating = true;
+          })
+          (mkBindWith "XF86MonBrightnessDown" ''hl.dsp.exec_cmd("brightnessctl s 10%-")'' {
+            locked = true;
+            repeating = true;
+          })
+
+          # Media player keys (previously bindl)
+          (mkBindWith "XF86AudioNext" ''hl.dsp.exec_cmd("playerctl next")'' { locked = true; })
+          (mkBindWith "XF86AudioPause" ''hl.dsp.exec_cmd("playerctl play-pause")'' { locked = true; })
+          (mkBindWith "XF86AudioPlay" ''hl.dsp.exec_cmd("playerctl play-pause")'' { locked = true; })
+          (mkBindWith "XF86AudioPrev" ''hl.dsp.exec_cmd("playerctl previous")'' { locked = true; })
         ];
 
-        bindm = [
-          "$mainMod, mouse:272, movewindow"
-          "$mainMod, mouse:273, resizewindow"
+        workspace_rule = [
+          {
+            workspace = ws_1;
+            monitor = "DP-1";
+            default = true;
+          }
+          {
+            workspace = ws_2;
+            monitor = "DP-2";
+            default = true;
+          }
+          {
+            workspace = ws_3;
+            monitor = "DP-2";
+            default = true;
+          }
+          {
+            workspace = ws_4;
+            monitor = "DP-2";
+            default = true;
+          }
+
+          {
+            workspace = "special:calculator";
+            on_created_empty = "[float; size 622 652] ${calculator}";
+          }
+          {
+            workspace = "special:passman";
+            on_created_empty = "[float; size 622 652] ${passman}";
+          }
+          {
+            workspace = "special:resourceman";
+            on_created_empty = "${terminal} -e ${resourceman}";
+          }
+          {
+            workspace = "special:obsidian";
+            on_created_empty = "${obsidianApp}";
+          }
         ];
 
-        bindel = [
-          ",XF86AudioRaiseVolume, exec, wpctl set-volume @DEFAULT_AUDIO_SINK@ 5%+"
-          ",XF86AudioLowerVolume, exec, wpctl set-volume @DEFAULT_AUDIO_SINK@ 5%-"
-          ",XF86AudioMute, exec, wpctl set-mute @DEFAULT_AUDIO_SINK@ toggle"
-          ",XF86AudioMicMute, exec, wpctl set-mute @DEFAULT_AUDIO_SOURCE@ toggle"
-          ",XF86MonBrightnessUp, exec, brightnessctl s 10%+"
-          ",XF86MonBrightnessDown, exec, brightnessctl s 10%-"
+        # Glass surfaces: blur the layer-shell UI (waybar islands, rofi card,
+        # dunst notifications) so their translucent backgrounds frost the
+        # content behind them. ignore_alpha keeps fully-transparent regions
+        # (bar gaps, rounded corners) from blurring.
+        layer_rule = [
+          {
+            match = {
+              namespace = "waybar";
+            };
+            blur = true;
+            ignore_alpha = 0.28;
+          }
+          {
+            match = {
+              namespace = "rofi";
+            };
+            blur = true;
+            ignore_alpha = 0.28;
+          }
+          {
+            match = {
+              namespace = "dunst";
+            };
+            blur = true;
+            ignore_alpha = 0.28;
+          }
         ];
 
-        bindl = [
-          ", XF86AudioNext, exec, playerctl next"
-          ", XF86AudioPause, exec, playerctl play-pause"
-          ", XF86AudioPlay, exec, playerctl play-pause"
-          ", XF86AudioPrev, exec, playerctl previous"
-        ];
+        on = {
+          _args = [
+            "hyprland.start"
+            (lua ''
+              function()
+                hl.exec_cmd("nm-applet --indicator")
+                hl.exec_cmd("clipse -listen")
 
-        rule = [
-
-        ];
-
-        workspace = [
-          "$ws_1, monitor:DP-1, default:true"
-          "$ws_2, monitor:DP-2, default:true"
-          "$ws_3, monitor:DP-2, default:true"
-          "$ws_4, monitor:DP-2, default:true"
-
-          # Smart workspace layouts
-          "$ws_1, layoutopt:orientation:left"
-          "$ws_2, layoutopt:orientation:top"
-          "$ws_3, layoutopt:orientation:right"
-          "$ws_4, layoutopt:orientation:center"
-
-          "special:calculator s[true]"
-          "special:passman s[true]"
-          "special:obsidian s[true]"
-        ];
-
-        # windowrule = [
-        #   "suppressevent maximize, class:.*"
-        #   "nofocus,class:^$,title:^$,xwayland:1,floating:1,fullscreen:0,pinned:0"
-
-        #   ######## SMART TILING RULES ########
-        #   # Browsers - optimized for reading and productivity
-        #   "size 70% 100%, class:^(brave-browser)$"
-        #   "tile, class:^(brave-browser)$"
-        #   "group set always, class:^(brave-browser)$"
-        #   "size 70% 100%, class:^(firefox)$"
-        #   "tile, class:^(firefox)$"
-        #   "group set always, class:^(firefox)$"
-
-        #   # Chrome-based browsers
-        #   "size 70% 100%, class:^(google-chrome)$"
-        #   "tile, class:^(google-chrome)$"
-        #   "group set always, class:^(google-chrome)$"
-
-        #   # IDEs and editors - generous space for productivity
-        #   "size 80% 90%, class:^(code)$"
-        #   "tile, class:^(code)$"
-        #   "center, class:^(code)$"
-        #   "group set always, class:^(code)$"
-
-        #   "size 80% 90%, class:^(neovim)$"
-        #   "tile, class:^(neovim)$"
-        #   "group set always, class:^(neovim)$"
-
-        #   "size 85% 95%, class:^(jetbrains-.*)$"
-        #   "tile, class:^(jetbrains-.*)$"
-        #   "center, class:^(jetbrains-.*)$"
-
-        #   # Terminals - golden ratio proportions for elegance
-        #   "size 61.8% 70%, class:^(kitty)$"
-        #   "tile, class:^(kitty)$"
-        #   "size 61.8% 70%, class:^(foot)$"
-        #   "tile, class:^(foot)$"
-        #   "size 61.8% 70%, class:^(com.mitchellh.ghostty)$"
-        #   "tile, class:^(com.mitchellh.ghostty)$"
-        #   "size 61.8% 70%, class:^(alacritty)$"
-        #   "tile, class:^(alacritty)$"
-
-        #   # Media applications - center stage
-        #   "size 80% 80%, class:^(mpv)$"
-        #   "center, class:^(mpv)$"
-        #   "size 85% 85%, class:^(vlc)$"
-        #   "center, class:^(vlc)$"
-
-        #   # Communication apps - sidebar friendly
-        #   "size 30% 80%, class:^(discord)$"
-        #   "tile, class:^(discord)$"
-        #   "size 30% 80%, class:^(slack)$"
-        #   "tile, class:^(slack)$"
-        #   "size 35% 85%, class:^(teams)$"
-        #   "tile, class:^(teams)$"
-
-        #   # File managers - explorer layout
-        #   "size 65% 75%, class:^(thunar)$"
-        #   "tile, class:^(thunar)$"
-        #   "size 65% 75%, class:^(nautilus)$"
-        #   "tile, class:^(nautilus)$"
-        #   "size 65% 75%, class:^(dolphin)$"
-        #   "tile, class:^(dolphin)$"
-
-        #   # System utilities - compact and efficient
-        #   "size 50% 60%, class:^(htop)$"
-        #   "center, class:^(htop)$"
-        #   "size 55% 65%, class:^(btop)$"
-        #   "center, class:^(btop)$"
-
-        #   ######## TAGS ########
-        #   # "tag:+browser class:^(brave-browser)$"
-        #   # "tag:+browser class:^(firefox)$"
-
-        #   # "tag:+ide class:^(code)$"
-
-        #   # "tag:+term class:^(kitty)$"
-        #   # "tag:+term class:^(foot)$"
-        #   # "tag:+term class:^(com.mitchellh.ghostty)$"
-
-        #   "float, class:(clipse)"
-        #   "size 622 652, class:(clipse)"
-        #   "stayfocused, class:(clipse)"
-
-        #   "float,class:($calculator)"
-        #   "workspace special:special:calculator,class:($calculator)"
-        #   "size 622 652, class:($calculator)"
-        #   "stayfocused, class:($calculator)"
-
-        #   "float,class:($passman)"
-        #   "workspace special:special:passman,class:($passman)"
-        #   "size 622 652, class:($passman)"
-        #   "stayfocused, class:($passman)"
-
-        #   "float,title:($resourceman)"
-        #   "workspace special:special:resourceman,title:($resourceman)"
-        #   "size 622 652, title:($resourceman)"
-        #   "stayfocused, title:($resourceman)"
-
-        #   "float,class:($obsidian)"
-        #   "workspace special:special:obsidian,class:($obsidian)"
-        #   "size 622 652, class:($obsidian)"
-        #   # "workspace name:ide tag:^ide$"
-        # ];
-
-        exec-once = [
-          "nm-applet --indicator"
-          "clipse -listen"
-
-          "[workspace $ws_1 silent] $terminal"
-          "[workspace $ws_2 silent] $ide"
-          "[workspace $ws_3 silent] $browser"
-          "[workspace $ws_4 silent] slack"
-        ];
+                hl.exec_cmd("[workspace ${ws_1} silent] ${terminal}")
+                hl.exec_cmd("[workspace ${ws_2} silent] ${ide}")
+                hl.exec_cmd("[workspace ${ws_3} silent] ${browser}")
+                hl.exec_cmd("[workspace ${ws_4} silent] slack")
+              end'')
+          ];
+        };
       };
 
       systemd = {
@@ -726,19 +709,10 @@ in
 
     home = {
       packages = with pkgs; [
-        rofi
         networkmanagerapplet
         brightnessctl
         playerctl
       ];
-
-      # pointerCursor = {
-      #   # gtk.enable = true;
-      #   # x11.enable = true;
-      #   package = pkgs.bibata-cursors;
-      #   name = "Bibata_AdaptaBreath_Cursors";
-      #   size = 16;
-      # };
     };
   };
 }

--- a/modules/home/hyprlock/default.nix
+++ b/modules/home/hyprlock/default.nix
@@ -93,14 +93,15 @@ in
         dots_spacing = 0.25
         dots_center = true
         dots_rounding = -1
-        outer_color = rgba(198, 160, 246, 0.8)
-        inner_color = rgba(36, 39, 58, 0.8)
+        # Mauve → teal → blue gradient ring, matching the Hyprland active border
+        outer_color = rgba(198, 160, 246, 0.9) rgba(139, 213, 202, 0.9) rgba(138, 173, 244, 0.9) 45deg
+        inner_color = rgba(30, 32, 48, 0.85)
         font_color = rgba(202, 211, 245, 1.0)
         fade_on_empty = true
         fade_timeout = 1000
         placeholder_text = <span foreground="##c6a0f6"><i>Keep it secret, keep it safe...</i></span>
         hide_input = false
-        rounding = 12
+        rounding = 14
         check_color = rgba(166, 218, 149, 0.8)
         fail_color = rgba(237, 135, 150, 0.8)
         fail_text = <i>The way is shut</i>

--- a/modules/home/packages/default.nix
+++ b/modules/home/packages/default.nix
@@ -16,12 +16,9 @@ let
     inherit (pkgs.stdenv.hostPlatform) system;
     config = {
       allowUnfree = true;
-      permittedInsecurePackages = [
-        "electron-38.8.4"
-        "nodejs-20.20.2"
-        "nodejs-slim-20.20.2"
-        "pnpm-10.29.2"
-      ];
+      permittedInsecurePackages = import (
+        lib.snowfall.fs.get-file "data/permitted-insecure-packages.nix"
+      );
     };
   };
 

--- a/modules/home/packages/default.nix
+++ b/modules/home/packages/default.nix
@@ -20,6 +20,7 @@ let
         "electron-38.8.4"
         "nodejs-20.20.2"
         "nodejs-slim-20.20.2"
+        "pnpm-10.29.2"
       ];
     };
   };
@@ -60,7 +61,9 @@ in
         jq
         k9s
         kitty
-        kubectl
+        # minikube bundles its own /bin/kubectl; give the standalone one priority
+        # so buildEnv resolves the collision in its favor instead of erroring.
+        (lib.hiPrio kubectl)
         kubectx
         kubernetes-helm
         lf

--- a/modules/home/rofi/default.nix
+++ b/modules/home/rofi/default.nix
@@ -1,0 +1,35 @@
+# @gitian:module Rofi launcher with a hand-crafted "macchiato-glass" rasi theme —
+# centered translucent card (frosted by the Hyprland rofi layer_rule blur), pill
+# input bar, and a mauve→blue gradient selection row matching the window borders.
+# Replaces the generic stylix rofi target, which is disabled in the theme module.
+{
+  lib,
+  config,
+  pkgs,
+  namespace,
+  ...
+}:
+let
+  cfg = config.${namespace}.rofi;
+in
+{
+  options.${namespace}.rofi = {
+    enable = lib.mkEnableOption "rofi";
+  };
+
+  config = lib.mkIf cfg.enable {
+    programs.rofi = {
+      enable = true;
+      font = "Ubuntu Sans 13";
+      terminal = "ghostty";
+      theme = ./macchiato-glass.rasi;
+      extraConfig = {
+        modi = "drun,run";
+        show-icons = true;
+        icon-theme = "Papirus-Dark";
+        display-drun = "󱓞";
+        drun-display-format = "{name}";
+      };
+    };
+  };
+}

--- a/modules/home/rofi/macchiato-glass.rasi
+++ b/modules/home/rofi/macchiato-glass.rasi
@@ -1,0 +1,101 @@
+/* Catppuccin Macchiato glass — translucent card frosted by the Hyprland
+ * rofi layer_rule blur; mauve→blue gradient selection row matching the
+ * compositor's active window border. */
+* {
+    bg:      rgba(30, 32, 48, 72%);
+    bg-alt:  rgba(24, 25, 38, 85%);
+    text:    #cad3f5;
+    muted:   #a5adcb;
+    mauve:   #c6a0f6;
+    teal:    #8bd5ca;
+    blue:    #8aadf4;
+    red:     #ed8796;
+    crust:   #181926;
+
+    background-color: transparent;
+    text-color: @text;
+}
+
+window {
+    transparency: "real";
+    location: center;
+    width: 640px;
+    background-color: @bg;
+    border: 2px;
+    border-color: rgba(198, 160, 246, 55%);
+    border-radius: 17px;
+    padding: 18px;
+}
+
+mainbox {
+    spacing: 14px;
+    children: [ inputbar, listview ];
+}
+
+inputbar {
+    spacing: 10px;
+    padding: 10px 16px;
+    background-color: @bg-alt;
+    border-radius: 999px;
+    children: [ prompt, entry ];
+}
+
+prompt {
+    text-color: @mauve;
+}
+
+entry {
+    placeholder: "Search…";
+    placeholder-color: @muted;
+    cursor: text;
+}
+
+listview {
+    lines: 7;
+    fixed-height: false;
+    spacing: 6px;
+    scrollbar: false;
+}
+
+element {
+    padding: 9px 14px;
+    border-radius: 12px;
+    spacing: 12px;
+}
+
+element-icon {
+    size: 26px;
+    background-color: transparent;
+}
+
+element-text {
+    background-color: transparent;
+    text-color: inherit;
+    vertical-align: 0.5;
+}
+
+element normal.normal,
+element alternate.normal {
+    background-color: transparent;
+}
+
+element selected.normal {
+    background-image: linear-gradient(to right, rgba(198, 160, 246, 90%), rgba(138, 173, 244, 90%));
+    text-color: @crust;
+}
+
+element urgent {
+    text-color: @red;
+}
+
+element active {
+    text-color: @teal;
+}
+
+message {
+    padding: 8px;
+}
+
+textbox {
+    text-color: @muted;
+}

--- a/modules/home/secrets/default.nix
+++ b/modules/home/secrets/default.nix
@@ -6,41 +6,51 @@
   config,
   inputs,
   lib,
+  namespace,
   ...
 }:
 let
   secrets = lib.snowfall.fs.get-file "secrets";
+  cfg = config.${namespace}.secrets;
 in
 {
-  imports = [ inputs.sops-nix.homeManagerModules.sops ];
-
-  sops = {
-    # age.keyFile = "/home/${config.snowfallorg.user.name}/.age-key.txt"; # must have no password!
-    # It's also possible to use a ssh key, but only when it has no password:
-    age.sshKeyPaths = [ "${config.home.homeDirectory}/.ssh/sops-nix" ];
-    defaultSopsFile = "${secrets}/${config.snowfallorg.user.name}.yaml";
-    # secrets.test = {
-    #   # sopsFile = ./secrets.yml.enc; # optionally define per-secret files
-
-    #   # %r gets replaced with a runtime directory, use %% to specify a '%'
-    #   # sign. Runtime dir is $XDG_RUNTIME_DIR on linux and $(getconf
-    #   # DARWIN_USER_TEMP_DIR) on darwin.
-    #   path = "%r/test.txt";
-    # };
-    #
-    secrets = {
-      "git/name" = { };
-      "git/email" = { };
-      "git/gh/ssh-private" = { };
-      "git/gh/ssh-public" = { };
-      "ai/anthropic/api-key" = { };
-      "ai/gemini/api-key" = { };
-      "localstack/auth-token" = { };
+  options.${namespace}.secrets = {
+    enable = lib.mkEnableOption "secrets" // {
+      default = true;
     };
   };
 
-  # export GEMINI_API_KEY="$(cat ${config.sops.secrets."ai/gemini/api-key".path})"
-  programs.zsh.initContent = "";
+  imports = [ inputs.sops-nix.homeManagerModules.sops ];
 
-  systemd.user.services.mbsync.unitConfig.After = [ "sops-nix.service" ];
+  config = lib.mkIf cfg.enable {
+    sops = {
+      # age.keyFile = "/home/${config.snowfallorg.user.name}/.age-key.txt"; # must have no password!
+      # It's also possible to use a ssh key, but only when it has no password:
+      age.sshKeyPaths = [ "${config.home.homeDirectory}/.ssh/sops-nix" ];
+      defaultSopsFile = "${secrets}/${config.snowfallorg.user.name}.yaml";
+      # secrets.test = {
+      #   # sopsFile = ./secrets.yml.enc; # optionally define per-secret files
+
+      #   # %r gets replaced with a runtime directory, use %% to specify a '%'
+      #   # sign. Runtime dir is $XDG_RUNTIME_DIR on linux and $(getconf
+      #   # DARWIN_USER_TEMP_DIR) on darwin.
+      #   path = "%r/test.txt";
+      # };
+      #
+      secrets = {
+        "git/name" = { };
+        "git/email" = { };
+        "git/gh/ssh-private" = { };
+        "git/gh/ssh-public" = { };
+        "ai/anthropic/api-key" = { };
+        "ai/gemini/api-key" = { };
+        "localstack/auth-token" = { };
+      };
+    };
+
+    # export GEMINI_API_KEY="$(cat ${config.sops.secrets."ai/gemini/api-key".path})"
+    programs.zsh.initContent = "";
+
+    systemd.user.services.mbsync.unitConfig.After = [ "sops-nix.service" ];
+  };
 }

--- a/modules/home/shell/default.nix
+++ b/modules/home/shell/default.nix
@@ -3,327 +3,340 @@
 # git alias system and shell aliases (bat, ripgrep, kubectl shortcuts).
 {
   config,
+  lib,
   pkgs,
+  namespace,
   ...
 }:
+let
+  cfg = config.${namespace}.shell;
+in
 {
-  home.shell.enableZshIntegration = true;
-
-  programs = {
-    fzf = {
-      enable = true;
-      enableZshIntegration = true;
+  options.${namespace}.shell = {
+    enable = lib.mkEnableOption "shell" // {
+      default = true;
     };
+  };
 
-    starship = {
-      enable = true;
-      settings = {
-        add_newline = true;
-        command_timeout = 1300;
-        scan_timeout = 50;
-        # format = ''$nix_shell$nodejs$lua$golang$rust$php$git_branch$git_commit$git_state$git_status$username$hostname$directory'';
-        character = {
-          success_symbol = "[](bold green) ";
-          error_symbol = "[✗](bold red) ";
+  config = lib.mkIf cfg.enable {
+    home.shell.enableZshIntegration = true;
+
+    programs = {
+      fzf = {
+        enable = true;
+        enableZshIntegration = true;
+      };
+
+      starship = {
+        enable = true;
+        settings = {
+          add_newline = true;
+          command_timeout = 1300;
+          scan_timeout = 50;
+          # format = ''$nix_shell$nodejs$lua$golang$rust$php$git_branch$git_commit$git_state$git_status$username$hostname$directory'';
+          character = {
+            success_symbol = "[](bold green) ";
+            error_symbol = "[✗](bold red) ";
+          };
+          golang = {
+            symbol = "";
+            style = "bg:#212736";
+            format = "[[ $symbol ($version) ](fg:#769ff0 bg:#212736)]($style)";
+          };
         };
-        golang = {
-          symbol = "";
-          style = "bg:#212736";
-          format = "[[ $symbol ($version) ](fg:#769ff0 bg:#212736)]($style)";
+      };
+
+      zsh = {
+        enable = true;
+        enableCompletion = true;
+        enableVteIntegration = false;
+        package = pkgs.zsh;
+        antidote = {
+          enable = false;
+          # package
+          # plugins
+          # useFriendlyNames
         };
-      };
-    };
+        autocd = true;
+        autosuggestion = {
+          enable = true;
+          # highlight = "fg=#ff00ff,bg=cyan,bold,underline";
+          # strategy
+        };
+        # cdpath
+        # completionInit = "autoload -U compinit && compinit -i";
+        # defaultKeymap
+        # dirHashes
+        dotDir = config.home.homeDirectory + "/.config/zsh";
+        envExtra = "";
+        history = {
+          append = true;
+          expireDuplicatesFirst = true;
+          extended = true;
+          # findNoDups
+          ignoreAllDups = true;
+          # ignoreDups
+          # ignorePatterns
+          ignoreSpace = true;
+          # path
+          save = 100000000;
+          # saveNoDups
+          # share
+          size = 1000000000;
+        };
+        historySubstringSearch = {
+          enable = true;
+          # zle puts the terminal in application cursor mode (smkx), where terminals that honor
+          # DECCKM (ghostty) send ^[OA/^[OB for arrows instead of ^[[A/^[[B — bind both forms
+          searchUpKey = [
+            "^[[A"
+            "^[OA"
+          ];
+          searchDownKey = [
+            "^[[B"
+            "^[OB"
+          ];
+        };
+        # initcontent
+        # export LANG=C.UTF-8
+        initContent = ''
+          export PATH=$PATH:~/go/bin
+          ZLE_PROMPT_INDENT=0
+          autopair-init
+        '';
+        # localVariables
+        # loginExtra
+        # logoutExtra
+        oh-my-zsh = {
+          enable = false;
+          # package
+          # custom
+          # extraConfig
+          plugins = [ ];
+          # theme = "half-life";
+        };
+        plugins = [
+          {
+            name = "formarks";
+            src = pkgs.fetchFromGitHub {
+              owner = "wfxr";
+              repo = "formarks";
+              rev = "8abce138218a8e6acd3c8ad2dd52550198625944";
+              sha256 = "1wr4ypv2b6a2w9qsia29mb36xf98zjzhp3bq4ix6r3cmra3xij90";
+            };
+            file = "formarks.plugin.zsh";
+          }
 
-    zsh = {
-      enable = true;
-      enableCompletion = true;
-      enableVteIntegration = false;
-      package = pkgs.zsh;
-      antidote = {
-        enable = false;
-        # package
-        # plugins
-        # useFriendlyNames
-      };
-      autocd = true;
-      autosuggestion = {
-        enable = true;
-        # highlight = "fg=#ff00ff,bg=cyan,bold,underline";
-        # strategy
-      };
-      # cdpath
-      # completionInit = "autoload -U compinit && compinit -i";
-      # defaultKeymap
-      # dirHashes
-      dotDir = config.home.homeDirectory + "/.config/zsh";
-      envExtra = "";
-      history = {
-        append = true;
-        expireDuplicatesFirst = true;
-        extended = true;
-        # findNoDups
-        ignoreAllDups = true;
-        # ignoreDups
-        # ignorePatterns
-        ignoreSpace = true;
-        # path
-        save = 100000000;
-        # saveNoDups
-        # share
-        size = 1000000000;
-      };
-      historySubstringSearch = {
-        enable = true;
-        # zle puts the terminal in application cursor mode (smkx), where terminals that honor
-        # DECCKM (ghostty) send ^[OA/^[OB for arrows instead of ^[[A/^[[B — bind both forms
-        searchUpKey = [
-          "^[[A"
-          "^[OA"
+          {
+            name = "zsh-completions";
+            src = pkgs.fetchFromGitHub {
+              owner = "zsh-users";
+              repo = "zsh-completions";
+              rev = "0.35.0";
+              hash = "sha256-GFHlZjIHUWwyeVoCpszgn4AmLPSSE8UVNfRmisnhkpg=";
+            };
+          }
+
+          {
+            name = "zsh-nix-shell";
+            file = "nix-shell.plugin.zsh";
+            src = pkgs.pkgs.fetchFromGitHub {
+              owner = "chisui";
+              repo = "zsh-nix-shell";
+              rev = "v0.8.0";
+              hash = "sha256-Z6EYQdasvpl1P78poj9efnnLj7QQg13Me8x1Ryyw+dM=";
+            };
+          }
+
+          {
+            name = "enhancd";
+            file = "init.sh";
+            src = pkgs.fetchFromGitHub {
+              owner = "b4b4r07";
+              repo = "enhancd";
+              rev = "v2.5.1";
+              hash = "sha256-kaintLXSfLH7zdLtcoZfVNobCJCap0S/Ldq85wd3krI=";
+            };
+          }
+
+          {
+            name = "zsh-autopair";
+            src = pkgs.fetchFromGitHub {
+              owner = "hlissner";
+              repo = "zsh-autopair";
+              rev = "34a8bca0c18fcf3ab1561caef9790abffc1d3d49";
+              sha256 = "1h0vm2dgrmb8i2pvsgis3lshc5b0ad846836m62y8h3rdb3zmpy1";
+            };
+            file = "autopair.zsh";
+          }
         ];
-        searchDownKey = [
-          "^[[B"
-          "^[OB"
-        ];
-      };
-      # initcontent
-      # export LANG=C.UTF-8
-      initContent = ''
-        export PATH=$PATH:~/go/bin
-        ZLE_PROMPT_INDENT=0
-        autopair-init
-      '';
-      # localVariables
-      # loginExtra
-      # logoutExtra
-      oh-my-zsh = {
-        enable = false;
-        # package
-        # custom
-        # extraConfig
-        plugins = [ ];
-        # theme = "half-life";
-      };
-      plugins = [
-        {
-          name = "formarks";
-          src = pkgs.fetchFromGitHub {
-            owner = "wfxr";
-            repo = "formarks";
-            rev = "8abce138218a8e6acd3c8ad2dd52550198625944";
-            sha256 = "1wr4ypv2b6a2w9qsia29mb36xf98zjzhp3bq4ix6r3cmra3xij90";
-          };
-          file = "formarks.plugin.zsh";
-        }
+        # prezto = {
+        #   enable = false;
+        #   # package
+        #   autosuggestions = {
+        #     # color
+        #   };
+        #   # caseSensitive
+        #   # color
+        #   completions = {
+        #     # ignoredHosts
+        #   };
+        #   editor = {
+        #     # dotExpansion
+        #     # keymap
+        #     # promptContext
+        #   };
+        #   # extraConfig
+        #   # extraFunctions
+        #   # extraModules
+        #   git = {
+        #     # submoduleIgnore
+        #   };
+        #   gnuUtility = {
+        #     # prefix
+        #   };
+        #   historySubstring = {
+        #     # foundColor
+        #     # globbingFlags
+        #     # notFoundColor
+        #   };
+        #   macOS = {
+        #     # dashKeyword
+        #   };
+        #   # pmoduleDirs
+        #   # pmodules
+        #   prompt = {
+        #     # pwdLength
+        #     # showReturnVal
+        #     # theme
+        #   };
+        #   python = {
+        #     # virtualenvAutoSwitch
+        #     # virtualenvInitialize
+        #   };
+        #   ruby = {
+        #     # chrubyAutoSwitch
+        #   };
+        #   screen = {
+        #     # autoStartLocal
+        #     # autoStartRemote
+        #   };
+        #   ssh = {
+        #     # identities
+        #   };
+        #   syntaxHighlighting = {
+        #     # highlighters
+        #     # pattern
+        #     # styles
+        #   };
+        #   terminal = {
+        #     # autoTitle
+        #     # multiplexerTitleFormat
+        #     # tabTitleFormat
+        #     # windowTitleFormat
+        #   };
+        #   tmux = {
+        #     # autoStartLocal
+        #     # autoStartRemote
+        #     # defaultSessionName
+        #     # itermIntegration
+        #   };
+        #   utility = {
+        #     # safeOps
+        #   };
+        # };
+        # profileExtra
+        # sessionVariables
+        shellAliases = {
+          cat = "${pkgs.bat}/bin/bat";
+          e = "\${EDITOR:-nvim}";
+          kc = "kubectl";
+          ll = "ls -la";
+          pw = "ps aux | grep -v grep | grep -e";
+          # vi = "nvim";
+          vim = "nvim";
+          vim_ready = "sleep 1";
 
-        {
-          name = "zsh-completions";
-          src = pkgs.fetchFromGitHub {
-            owner = "zsh-users";
-            repo = "zsh-completions";
-            rev = "0.35.0";
-            hash = "sha256-GFHlZjIHUWwyeVoCpszgn4AmLPSSE8UVNfRmisnhkpg=";
-          };
-        }
+          rg = "rg --color=auto";
+          grep = "rg";
 
-        {
-          name = "zsh-nix-shell";
-          file = "nix-shell.plugin.zsh";
-          src = pkgs.pkgs.fetchFromGitHub {
-            owner = "chisui";
-            repo = "zsh-nix-shell";
-            rev = "v0.8.0";
-            hash = "sha256-Z6EYQdasvpl1P78poj9efnnLj7QQg13Me8x1Ryyw+dM=";
-          };
-        }
+          # use 'fc -El 1' for "dd.mm.yyyy"
+          # use 'fc -il 1' for "yyyy-mm-dd"
+          # use 'fc -fl 1' for mm/dd/yyyy
+          history = "fc -il 1";
 
-        {
-          name = "enhancd";
-          file = "init.sh";
-          src = pkgs.fetchFromGitHub {
-            owner = "b4b4r07";
-            repo = "enhancd";
-            rev = "v2.5.1";
-            hash = "sha256-kaintLXSfLH7zdLtcoZfVNobCJCap0S/Ldq85wd3krI=";
-          };
-        }
+          # git
+          g = "git";
 
-        {
-          name = "zsh-autopair";
-          src = pkgs.fetchFromGitHub {
-            owner = "hlissner";
-            repo = "zsh-autopair";
-            rev = "34a8bca0c18fcf3ab1561caef9790abffc1d3d49";
-            sha256 = "1h0vm2dgrmb8i2pvsgis3lshc5b0ad846836m62y8h3rdb3zmpy1";
-          };
-          file = "autopair.zsh";
-        }
-      ];
-      # prezto = {
-      #   enable = false;
-      #   # package
-      #   autosuggestions = {
-      #     # color
-      #   };
-      #   # caseSensitive
-      #   # color
-      #   completions = {
-      #     # ignoredHosts
-      #   };
-      #   editor = {
-      #     # dotExpansion
-      #     # keymap
-      #     # promptContext
-      #   };
-      #   # extraConfig
-      #   # extraFunctions
-      #   # extraModules
-      #   git = {
-      #     # submoduleIgnore
-      #   };
-      #   gnuUtility = {
-      #     # prefix
-      #   };
-      #   historySubstring = {
-      #     # foundColor
-      #     # globbingFlags
-      #     # notFoundColor
-      #   };
-      #   macOS = {
-      #     # dashKeyword
-      #   };
-      #   # pmoduleDirs
-      #   # pmodules
-      #   prompt = {
-      #     # pwdLength
-      #     # showReturnVal
-      #     # theme
-      #   };
-      #   python = {
-      #     # virtualenvAutoSwitch
-      #     # virtualenvInitialize
-      #   };
-      #   ruby = {
-      #     # chrubyAutoSwitch
-      #   };
-      #   screen = {
-      #     # autoStartLocal
-      #     # autoStartRemote
-      #   };
-      #   ssh = {
-      #     # identities
-      #   };
-      #   syntaxHighlighting = {
-      #     # highlighters
-      #     # pattern
-      #     # styles
-      #   };
-      #   terminal = {
-      #     # autoTitle
-      #     # multiplexerTitleFormat
-      #     # tabTitleFormat
-      #     # windowTitleFormat
-      #   };
-      #   tmux = {
-      #     # autoStartLocal
-      #     # autoStartRemote
-      #     # defaultSessionName
-      #     # itermIntegration
-      #   };
-      #   utility = {
-      #     # safeOps
-      #   };
-      # };
-      # profileExtra
-      # sessionVariables
-      shellAliases = {
-        cat = "${pkgs.bat}/bin/bat";
-        e = "\${EDITOR:-nvim}";
-        kc = "kubectl";
-        ll = "ls -la";
-        pw = "ps aux | grep -v grep | grep -e";
-        # vi = "nvim";
-        vim = "nvim";
-        vim_ready = "sleep 1";
+          gsha = "g rev-parse HEAD";
+          gsha-short = "g rev-parse --short HEAD";
+          branch = "g rev-parse --abbrev-ref HEAD";
 
-        rg = "rg --color=auto";
-        grep = "rg";
+          gdown = "git pull origin $(branch) --rebase";
+          gch = "g checkout";
+          gchb = "gch --detach";
+          gsw = "g switch";
+          gswC = "gsw -C";
+          gswm = "if [[ `git show-ref --verify --quiet refs/heads/main echo $?` -eq 0 ]]; then gf && gch main; else gf && gch main; fi && gdown";
+          ga = "g add";
+          "ga!" = "ga .";
+          gf = "g fetch";
+          gs = "git status";
+          gc = "g commit --verbose";
+          gcm = "gc -m";
+          gca = "gc --amend --no-edit";
+          gcp = "g cherry-pick";
+          gcpc = "gcp --continue";
+          gcpa = "gcp --abort";
+          gd = "g diff";
+          gup = "g push -v origin HEAD:refs/heads/$(branch)";
+          gupf = "gup --force-with-lease";
+          "gupf!" = "gup --force";
+          glog = "git log";
+          gloga = "glog --show-signature";
+          glogo = "glog --oneline";
+          glogog = "glogo --graph";
+          gr = "g rebase";
+          grm = "gr origin/trunk";
+          grc = "gr --continue";
+          gra = "gr --abort";
+          gbb = "g for-each-ref --color --sort=-committerdate --format=$'%(color:red)%(ahead-behind:HEAD)	%(color:blue)%(refname:short)	%(color:yellow)%(committerdate:relative)	%(color:default)%(describe)' refs/heads/ --no-merged | sed 's/ /	/' | column --separator=$'	' --table --table-columns='Ahead,Behind,Branch Name,Last Commit,Description'";
+          gst = "g stash";
+          gstp = "gst pop";
+          gstl = "gst list";
+          vpn-up = "sudo wg-quick up wg0";
+          vpn-down = "sudo wg-quick down wg0";
 
-        # use 'fc -El 1' for "dd.mm.yyyy"
-        # use 'fc -il 1' for "yyyy-mm-dd"
-        # use 'fc -fl 1' for mm/dd/yyyy
-        history = "fc -il 1";
-
-        # git
-        g = "git";
-
-        gsha = "g rev-parse HEAD";
-        gsha-short = "g rev-parse --short HEAD";
-        branch = "g rev-parse --abbrev-ref HEAD";
-
-        gdown = "git pull origin $(branch) --rebase";
-        gch = "g checkout";
-        gchb = "gch --detach";
-        gsw = "g switch";
-        gswC = "gsw -C";
-        gswm = "if [[ `git show-ref --verify --quiet refs/heads/main echo $?` -eq 0 ]]; then gf && gch main; else gf && gch main; fi && gdown";
-        ga = "g add";
-        "ga!" = "ga .";
-        gf = "g fetch";
-        gs = "git status";
-        gc = "g commit --verbose";
-        gcm = "gc -m";
-        gca = "gc --amend --no-edit";
-        gcp = "g cherry-pick";
-        gcpc = "gcp --continue";
-        gcpa = "gcp --abort";
-        gd = "g diff";
-        gup = "g push -v origin HEAD:refs/heads/$(branch)";
-        gupf = "gup --force-with-lease";
-        "gupf!" = "gup --force";
-        glog = "git log";
-        gloga = "glog --show-signature";
-        glogo = "glog --oneline";
-        glogog = "glogo --graph";
-        gr = "g rebase";
-        grm = "gr origin/trunk";
-        grc = "gr --continue";
-        gra = "gr --abort";
-        gbb = "g for-each-ref --color --sort=-committerdate --format=$'%(color:red)%(ahead-behind:HEAD)	%(color:blue)%(refname:short)	%(color:yellow)%(committerdate:relative)	%(color:default)%(describe)' refs/heads/ --no-merged | sed 's/ /	/' | column --separator=$'	' --table --table-columns='Ahead,Behind,Branch Name,Last Commit,Description'";
-        gst = "g stash";
-        gstp = "gst pop";
-        gstl = "gst list";
-        vpn-up = "sudo wg-quick up wg0";
-        vpn-down = "sudo wg-quick down wg0";
-
-        c = "codium";
-        cdot = "c .";
-        csys = "c ~/.sys";
-      };
-      # shellGlobalAliases
-      syntaxHighlighting = {
-        enable = true;
+          c = "codium";
+          cdot = "c .";
+          csys = "c ~/.sys";
+        };
+        # shellGlobalAliases
+        syntaxHighlighting = {
+          enable = true;
+          #   package
+          #   highlighters
+          #   patterns
+          #   styles
+        };
+        # zplug = {
+        #   enable
+        #   plugins = {
+        #     *.name
+        #     *.tags
+        #   };
+        #   zplugHome
+        # };
+        # zprof = {
+        #   enable
+        # };
+        # zsh-abbr = {
+        #   enable
         #   package
-        #   highlighters
-        #   patterns
-        #   styles
+        #   abbreviations
+        #   globalAbbreviations
+        # };
       };
-      # zplug = {
-      #   enable
-      #   plugins = {
-      #     *.name
-      #     *.tags
-      #   };
-      #   zplugHome
-      # };
-      # zprof = {
-      #   enable
-      # };
-      # zsh-abbr = {
-      #   enable
-      #   package
-      #   abbreviations
-      #   globalAbbreviations
-      # };
     };
   };
 }

--- a/modules/home/shell/default.nix
+++ b/modules/home/shell/default.nix
@@ -74,8 +74,16 @@
       };
       historySubstringSearch = {
         enable = true;
-        # searchDownKey = "$key[Down]";
-        # searchUpKey = "$key[Up]";
+        # zle puts the terminal in application cursor mode (smkx), where terminals that honor
+        # DECCKM (ghostty) send ^[OA/^[OB for arrows instead of ^[[A/^[[B — bind both forms
+        searchUpKey = [
+          "^[[A"
+          "^[OA"
+        ];
+        searchDownKey = [
+          "^[[B"
+          "^[OB"
+        ];
       };
       # initcontent
       # export LANG=C.UTF-8

--- a/modules/home/ssh/default.nix
+++ b/modules/home/ssh/default.nix
@@ -2,35 +2,51 @@
 # `gh-personal` key maps to `github.com` directly.
 # `gh-work` key maps to `gitwork` host alias (resolves to `github.com`).
 # Work repos use `gitwork:org/repo` as remote URL to trigger the correct key.
-{ ... }:
 {
-  programs.ssh = {
-    enable = true;
-    enableDefaultConfig = false;
-    settings = {
-      "github.com" = {
-        HostName = "github.com";
-        User = "git";
-        IdentitiesOnly = true;
-        IdentityFile = "~/.ssh/gh-personal";
-      };
-      gitwork = {
-        HostName = "github.com";
-        User = "git";
-        IdentitiesOnly = true;
-        IdentityFile = "~/.ssh/gh-work";
-      };
-      "*" = {
-        ForwardAgent = false;
-        AddKeysToAgent = "no";
-        Compression = false;
-        ServerAliveInterval = 0;
-        ServerAliveCountMax = 3;
-        HashKnownHosts = false;
-        UserKnownHostsFile = "~/.ssh/known_hosts";
-        ControlMaster = "no";
-        ControlPath = "~/.ssh/master-%r@%n:%p";
-        ControlPersist = "no";
+  lib,
+  config,
+  namespace,
+  ...
+}:
+let
+  cfg = config.${namespace}.ssh;
+in
+{
+  options.${namespace}.ssh = {
+    enable = lib.mkEnableOption "ssh" // {
+      default = true;
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    programs.ssh = {
+      enable = true;
+      enableDefaultConfig = false;
+      settings = {
+        "github.com" = {
+          HostName = "github.com";
+          User = "git";
+          IdentitiesOnly = true;
+          IdentityFile = "~/.ssh/gh-personal";
+        };
+        gitwork = {
+          HostName = "github.com";
+          User = "git";
+          IdentitiesOnly = true;
+          IdentityFile = "~/.ssh/gh-work";
+        };
+        "*" = {
+          ForwardAgent = false;
+          AddKeysToAgent = "no";
+          Compression = false;
+          ServerAliveInterval = 0;
+          ServerAliveCountMax = 3;
+          HashKnownHosts = false;
+          UserKnownHostsFile = "~/.ssh/known_hosts";
+          ControlMaster = "no";
+          ControlPath = "~/.ssh/master-%r@%n:%p";
+          ControlPersist = "no";
+        };
       };
     };
   };

--- a/modules/home/ssh/default.nix
+++ b/modules/home/ssh/default.nix
@@ -7,32 +7,30 @@
   programs.ssh = {
     enable = true;
     enableDefaultConfig = false;
-    matchBlocks = {
-      personal = {
-        host = "github.com";
-        hostname = "github.com";
-        user = "git";
-        identitiesOnly = true;
-        identityFile = "~/.ssh/gh-personal";
+    settings = {
+      "github.com" = {
+        HostName = "github.com";
+        User = "git";
+        IdentitiesOnly = true;
+        IdentityFile = "~/.ssh/gh-personal";
       };
-      work = {
-        host = "gitwork";
-        hostname = "github.com";
-        user = "git";
-        identitiesOnly = true;
-        identityFile = "~/.ssh/gh-work";
+      gitwork = {
+        HostName = "github.com";
+        User = "git";
+        IdentitiesOnly = true;
+        IdentityFile = "~/.ssh/gh-work";
       };
       "*" = {
-        forwardAgent = false;
-        addKeysToAgent = "no";
-        compression = false;
-        serverAliveInterval = 0;
-        serverAliveCountMax = 3;
-        hashKnownHosts = false;
-        userKnownHostsFile = "~/.ssh/known_hosts";
-        controlMaster = "no";
-        controlPath = "~/.ssh/master-%r@%n:%p";
-        controlPersist = "no";
+        ForwardAgent = false;
+        AddKeysToAgent = "no";
+        Compression = false;
+        ServerAliveInterval = 0;
+        ServerAliveCountMax = 3;
+        HashKnownHosts = false;
+        UserKnownHostsFile = "~/.ssh/known_hosts";
+        ControlMaster = "no";
+        ControlPath = "~/.ssh/master-%r@%n:%p";
+        ControlPersist = "no";
       };
     };
   };

--- a/modules/home/theme/default.nix
+++ b/modules/home/theme/default.nix
@@ -71,8 +71,17 @@
       librewolf.profileNames = [ "default" ];
       zed.enable = false;
 
-      # Better Rofi styling
-      rofi.enable = true;
+      # Stylix still injects hyprlang-style dotted keys ("col.active_border") into
+      # wayland.windowManager.hyprland.settings, which are invalid under the Lua
+      # config (configType = "lua"); the hyprland module carries the same
+      # Catppuccin Macchiato palette itself.
+      hyprland.enable = false;
+
+      # Rofi and dunst carry hand-crafted Macchiato-glass themes in their own
+      # modules; stylix's generic targets would fight them (theme option
+      # conflict for rofi, color overrides for dunst).
+      rofi.enable = false;
+      dunst.enable = false;
 
       # GTK theming
       gtk.enable = true;

--- a/modules/home/theme/default.nix
+++ b/modules/home/theme/default.nix
@@ -2,98 +2,112 @@
 # all home-manager targets. Opacity, fonts, wallpaper, and polarity are set here.
 # Stylix auto-enables on most targets; Zed is explicitly disabled (uses its own theme).
 {
+  lib,
+  config,
   inputs,
   pkgs,
+  namespace,
   ...
 }:
+let
+  cfg = config.${namespace}.theme;
+in
 {
+  options.${namespace}.theme = {
+    enable = lib.mkEnableOption "theme" // {
+      default = true;
+    };
+  };
+
   imports = [ inputs.stylix.homeModules.stylix ];
 
-  home.packages = with pkgs; [
-    # Icon fonts
-    font-awesome
-    material-design-icons
+  config = lib.mkIf cfg.enable {
+    home.packages = with pkgs; [
+      # Icon fonts
+      font-awesome
+      material-design-icons
 
-    # Nerd fonts for terminal/editor icons
-    nerd-fonts.intone-mono
-    nerd-fonts.symbols-only
-  ];
+      # Nerd fonts for terminal/editor icons
+      nerd-fonts.intone-mono
+      nerd-fonts.symbols-only
+    ];
 
-  stylix = {
-    enable = true;
+    stylix = {
+      enable = true;
 
-    autoEnable = true;
+      autoEnable = true;
 
-    opacity = {
-      applications = 0.96;
-      desktop = 1.0;
-      popups = 0.94;
-      terminal = 0.92;
-    };
-
-    base16Scheme = ./theme/base16/catppuccin/macciato.yaml;
-
-    fonts = {
-      monospace = {
-        name = "IntoneMono Nerd Font Mono";
-        package = pkgs.nerd-fonts.intone-mono;
+      opacity = {
+        applications = 0.96;
+        desktop = 1.0;
+        popups = 0.94;
+        terminal = 0.92;
       };
 
-      sansSerif = {
-        name = "Ubuntu Sans";
-        package = pkgs.ubuntu-sans;
+      base16Scheme = ./theme/base16/catppuccin/macciato.yaml;
+
+      fonts = {
+        monospace = {
+          name = "IntoneMono Nerd Font Mono";
+          package = pkgs.nerd-fonts.intone-mono;
+        };
+
+        sansSerif = {
+          name = "Ubuntu Sans";
+          package = pkgs.ubuntu-sans;
+        };
+
+        serif = {
+          name = "Ubuntu";
+          package = pkgs.ubuntu-classic;
+        };
+
+        emoji = {
+          name = "Noto Color Emoji";
+          package = pkgs.noto-fonts-color-emoji;
+        };
+
+        sizes = {
+          applications = 11;
+          desktop = 11;
+          popups = 11;
+          terminal = 13;
+        };
       };
 
-      serif = {
-        name = "Ubuntu";
-        package = pkgs.ubuntu-classic;
+      image = ./theme/wallpapers/rx7.png;
+
+      polarity = "dark";
+
+      targets = {
+        firefox.profileNames = [ "default" ];
+        librewolf.profileNames = [ "default" ];
+        zed.enable = false;
+
+        # Stylix still injects hyprlang-style dotted keys ("col.active_border") into
+        # wayland.windowManager.hyprland.settings, which are invalid under the Lua
+        # config (configType = "lua"); the hyprland module carries the same
+        # Catppuccin Macchiato palette itself.
+        hyprland.enable = false;
+
+        # Rofi and dunst carry hand-crafted Macchiato-glass themes in their own
+        # modules; stylix's generic targets would fight them (theme option
+        # conflict for rofi, color overrides for dunst).
+        rofi.enable = false;
+        dunst.enable = false;
+
+        # GTK theming
+        gtk.enable = true;
+
+        # Foot terminal
+        foot.enable = true;
+
+        # Bat (cat replacement)
+        bat.enable = true;
+
+        # fzf
+        fzf.enable = true;
       };
-
-      emoji = {
-        name = "Noto Color Emoji";
-        package = pkgs.noto-fonts-color-emoji;
-      };
-
-      sizes = {
-        applications = 11;
-        desktop = 11;
-        popups = 11;
-        terminal = 13;
-      };
-    };
-
-    image = ./theme/wallpapers/rx7.png;
-
-    polarity = "dark";
-
-    targets = {
-      firefox.profileNames = [ "default" ];
-      librewolf.profileNames = [ "default" ];
-      zed.enable = false;
-
-      # Stylix still injects hyprlang-style dotted keys ("col.active_border") into
-      # wayland.windowManager.hyprland.settings, which are invalid under the Lua
-      # config (configType = "lua"); the hyprland module carries the same
-      # Catppuccin Macchiato palette itself.
-      hyprland.enable = false;
-
-      # Rofi and dunst carry hand-crafted Macchiato-glass themes in their own
-      # modules; stylix's generic targets would fight them (theme option
-      # conflict for rofi, color overrides for dunst).
-      rofi.enable = false;
-      dunst.enable = false;
-
-      # GTK theming
-      gtk.enable = true;
-
-      # Foot terminal
-      foot.enable = true;
-
-      # Bat (cat replacement)
-      bat.enable = true;
-
-      # fzf
-      fzf.enable = true;
     };
   };
 }

--- a/modules/home/tmux/default.nix
+++ b/modules/home/tmux/default.nix
@@ -1,22 +1,36 @@
 {
+  lib,
+  config,
   pkgs,
+  namespace,
   ...
 }:
+let
+  cfg = config.${namespace}.tmux;
+in
 {
-  programs.tmux = {
-    enable = true;
-    mouse = true;
-    terminal = "tmux-256color";
-    historyLimit = 50000;
-    escapeTime = 10;
-    baseIndex = 1;
-    keyMode = "vi";
-    extraConfig = ''
-      # Enable true color support
-      set -ag terminal-overrides ",xterm-256color:RGB"
+  options.${namespace}.tmux = {
+    enable = lib.mkEnableOption "tmux" // {
+      default = true;
+    };
+  };
 
-      # Renumber windows when one is closed
-      set -g renumber-windows on
-    '';
+  config = lib.mkIf cfg.enable {
+    programs.tmux = {
+      enable = true;
+      mouse = true;
+      terminal = "tmux-256color";
+      historyLimit = 50000;
+      escapeTime = 10;
+      baseIndex = 1;
+      keyMode = "vi";
+      extraConfig = ''
+        # Enable true color support
+        set -ag terminal-overrides ",xterm-256color:RGB"
+
+        # Renumber windows when one is closed
+        set -g renumber-windows on
+      '';
+    };
   };
 }

--- a/modules/home/vscode/default.nix
+++ b/modules/home/vscode/default.nix
@@ -1,267 +1,280 @@
 {
   lib,
+  config,
   pkgs,
+  namespace,
   ...
 }:
+let
+  cfg = config.${namespace}.vscode;
+in
 {
-  programs = {
-    vscode = {
-      # Disabled: config retained, package not installed. Flip to true to reinstate.
-      enable = false;
-      package = pkgs.vscode;
+  options.${namespace}.vscode = {
+    enable = lib.mkEnableOption "vscode" // {
+      default = true;
+    };
+  };
 
-      profiles.default = {
-        enableUpdateCheck = true;
-        enableExtensionUpdateCheck = true;
-        userSettings = {
-          "explorer.fileNesting.patterns.*.ts" = "\${capture}.js";
-          "explorer.fileNesting.patterns.*.js" = "\${capture}.js.map, \${capture}.min.js, \${capture}.d.ts";
-          "explorer.fileNesting.patterns.*.jsx" = "\${capture}.js";
-          "explorer.fileNesting.patterns.*.tsx" = "\${capture}.ts";
-          "explorer.fileNesting.patterns.tsconfig.json" = "tsconfig.*.json";
-          "explorer.fileNesting.patterns.package.json" =
-            "package-lock.json, yarn.lock, pnpm-lock.yaml, bun.lockb";
-          "explorer.fileNesting.patterns.*.sqlite" = "\${capture}.\${extname}-*";
-          "explorer.fileNesting.patterns.*.db" = "\${capture}.\${extname}-*";
-          "explorer.fileNesting.patterns.*.sqlite3" = "\${capture}.\${extname}-*";
-          "explorer.fileNesting.patterns.*.db3" = "\${capture}.\${extname}-*";
-          "explorer.fileNesting.patterns.*.sdb" = "\${capture}.\${extname}-*";
-          "explorer.fileNesting.patterns.*.s3db" = "\${capture}.\${extname}-*";
+  config = lib.mkIf cfg.enable {
+    programs = {
+      vscode = {
+        # Disabled: config retained, package not installed. Flip to true to reinstate.
+        enable = false;
+        package = pkgs.vscode;
 
-          "nix.enableLanguageServer" = true;
-          "nix.serverPath" = "nil";
+        profiles.default = {
+          enableUpdateCheck = true;
+          enableExtensionUpdateCheck = true;
+          userSettings = {
+            "explorer.fileNesting.patterns.*.ts" = "\${capture}.js";
+            "explorer.fileNesting.patterns.*.js" = "\${capture}.js.map, \${capture}.min.js, \${capture}.d.ts";
+            "explorer.fileNesting.patterns.*.jsx" = "\${capture}.js";
+            "explorer.fileNesting.patterns.*.tsx" = "\${capture}.ts";
+            "explorer.fileNesting.patterns.tsconfig.json" = "tsconfig.*.json";
+            "explorer.fileNesting.patterns.package.json" =
+              "package-lock.json, yarn.lock, pnpm-lock.yaml, bun.lockb";
+            "explorer.fileNesting.patterns.*.sqlite" = "\${capture}.\${extname}-*";
+            "explorer.fileNesting.patterns.*.db" = "\${capture}.\${extname}-*";
+            "explorer.fileNesting.patterns.*.sqlite3" = "\${capture}.\${extname}-*";
+            "explorer.fileNesting.patterns.*.db3" = "\${capture}.\${extname}-*";
+            "explorer.fileNesting.patterns.*.sdb" = "\${capture}.\${extname}-*";
+            "explorer.fileNesting.patterns.*.s3db" = "\${capture}.\${extname}-*";
 
-          "nix.serverSettings" = {
-            "nil" = {
-              "formatting" = {
-                "command" = [ "nixfmt" ];
+            "nix.enableLanguageServer" = true;
+            "nix.serverPath" = "nil";
+
+            "nix.serverSettings" = {
+              "nil" = {
+                "formatting" = {
+                  "command" = [ "nixfmt" ];
+                };
               };
             };
-          };
 
-          "[json].editor.defaultFormatter" = "esbenp.prettier-vscode";
+            "[json].editor.defaultFormatter" = "esbenp.prettier-vscode";
 
-          "sqliteViewer.maxFileSize" = 1000;
+            "sqliteViewer.maxFileSize" = 1000;
 
-          "editor.multiCursorLimit" = 100000;
+            "editor.multiCursorLimit" = 100000;
 
-          "files.autoSave" = "off";
-          "files.eol" = "\n";
-          "files.associations" = {
-            "*.jsx" = "javascriptreact";
-          };
-          "files.insertFinalNewline" = true;
+            "files.autoSave" = "off";
+            "files.eol" = "\n";
+            "files.associations" = {
+              "*.jsx" = "javascriptreact";
+            };
+            "files.insertFinalNewline" = true;
 
-          "javascript.updateImportsOnFileMove.enabled" = "never";
-          "[javascript]" = {
-            "editor.defaultFormatter" = "esbenp.prettier-vscode";
-          };
-          "[javascriptreact]" = {
-            "editor.defaultFormatter" = "esbenp.prettier-vscode";
-          };
-
-          "typescript.updateImportsOnFileMove.enabled" = "never";
-          "[typescript]" = {
-            "editor.defaultFormatter" = "esbenp.prettier-vscode";
-          };
-          "[typescriptreact]" = {
-            "editor.defaultFormatter" = "esbenp.prettier-vscode";
-          };
-
-          # golang
-          "go" = {
-            "buildTags" = "";
-            "coverOnSingleTestFile" = true;
-            "coverOnSingleTest" = true;
-            "formatTool" = "gofmt";
-            "autocompleteUnimportedPackages" = true;
-            "lintTool" = "golangci-lint";
-            "toolsManagement.autoUpdate" = true;
-            "disableConcurrentTests" = true;
-
-            "inlayHints" = {
-              "assignVariableTypes" = true;
-              "compositeLiteralFields" = true;
-              "compositeLiteralTypes" = true;
-              "constantValues" = true;
+            "javascript.updateImportsOnFileMove.enabled" = "never";
+            "[javascript]" = {
+              "editor.defaultFormatter" = "esbenp.prettier-vscode";
+            };
+            "[javascriptreact]" = {
+              "editor.defaultFormatter" = "esbenp.prettier-vscode";
             };
 
-            # "lintFlags" = [
-            #   "--path-mode=abs"
-            #   "--fast-only"
-            # ];
-
-            # "alternateTools" = {
-            #   "customFormatter" = "golangci-lint";
-            # };
-
-            "formatFlags" = [
-              "fmt"
-              "--stdin"
-            ];
-
-            "testFlags" = [ ];
-            "liveErrors" = {
-              "enabled" = true;
-              "delay" = 100;
+            "typescript.updateImportsOnFileMove.enabled" = "never";
+            "[typescript]" = {
+              "editor.defaultFormatter" = "esbenp.prettier-vscode";
             };
-          };
-
-          "[go]" = {
-            "editor.formatOnSave" = true;
-            "editor.codeActionsOnSave" = {
-              "source.organizeImports" = "explicit";
+            "[typescriptreact]" = {
+              "editor.defaultFormatter" = "esbenp.prettier-vscode";
             };
-            # // Disable snippets; as they conflict with completion ranking.
-            "editor.snippetSuggestions" = "none";
+
+            # golang
+            "go" = {
+              "buildTags" = "";
+              "coverOnSingleTestFile" = true;
+              "coverOnSingleTest" = true;
+              "formatTool" = "gofmt";
+              "autocompleteUnimportedPackages" = true;
+              "lintTool" = "golangci-lint";
+              "toolsManagement.autoUpdate" = true;
+              "disableConcurrentTests" = true;
+
+              "inlayHints" = {
+                "assignVariableTypes" = true;
+                "compositeLiteralFields" = true;
+                "compositeLiteralTypes" = true;
+                "constantValues" = true;
+              };
+
+              # "lintFlags" = [
+              #   "--path-mode=abs"
+              #   "--fast-only"
+              # ];
+
+              # "alternateTools" = {
+              #   "customFormatter" = "golangci-lint";
+              # };
+
+              "formatFlags" = [
+                "fmt"
+                "--stdin"
+              ];
+
+              "testFlags" = [ ];
+              "liveErrors" = {
+                "enabled" = true;
+                "delay" = 100;
+              };
+            };
+
+            "[go]" = {
+              "editor.formatOnSave" = true;
+              "editor.codeActionsOnSave" = {
+                "source.organizeImports" = "explicit";
+              };
+              # // Disable snippets; as they conflict with completion ranking.
+              "editor.snippetSuggestions" = "none";
+              "[go.mod]" = {
+                "editor.codeActionsOnSave" = {
+                  "source.organizeImports" = "explicit";
+                };
+              };
+            };
+
             "[go.mod]" = {
+              "editor.formatOnSave" = true;
               "editor.codeActionsOnSave" = {
                 "source.organizeImports" = "explicit";
               };
             };
-          };
 
-          "[go.mod]" = {
+            "gopls" = {
+              "buildFlags" = [ ];
+              # // Add parameter placeholders when completing a function.
+              "usePlaceholders" = true;
+              # // If true; enable additional analyses with staticcheck.
+              # // Warning = This will significantly increase memory usage.
+              "staticcheck" = false;
+              "analyses" = {
+                "fillstruct" = false;
+              };
+            };
+
+            "[html]" = {
+              "editor.defaultFormatter" = "vscode.html-language-features";
+            };
+
+            "[json]" = {
+              "editor.defaultFormatter" = "vscode.json-language-features";
+            };
+
+            "[jsonc]" = {
+              "editor.defaultFormatter" = "esbenp.prettier-vscode";
+            };
+
+            "[graphql]" = {
+              "editor.formatOnSave" = false;
+            };
+
+            "editor.suggestSelection" = "first";
+            "editor.fontLigatures" = true;
+            "editor.wordWrap" = "on";
+            "editor.tabSize" = 2;
+            "editor.unicodeHighlight.invisibleCharacters" = false;
             "editor.formatOnSave" = true;
-            "editor.codeActionsOnSave" = {
-              "source.organizeImports" = "explicit";
+            # "editor.fontSize" = 11;
+
+            "vsintellicode.modify.editor.suggestSelection" = "automaticallyOverrodeDefaultValue";
+
+            "search.exclude" = {
+              "**/node_modules" = false;
+              "**/bower_components" = true;
+              "**/*.code-search" = true;
             };
+
+            "gitlens.hovers.currentLine.over" = "line";
+            "diffEditor.ignoreTrimWhitespace" = true;
+
+            "yaml.customTags" = [
+              "!And"
+              "!And sequence"
+              "!If"
+              "!If sequence"
+              "!Not"
+              "!Not sequence"
+              "!Equals"
+              "!Equals sequence"
+              "!Or"
+              "!Or sequence"
+              "!FindInMap"
+              "!FindInMap sequence"
+              "!Base64"
+              "!Join"
+              "!Join sequence"
+              "!Cidr"
+              "!Ref"
+              "!Sub"
+              "!Sub sequence"
+              "!GetAtt"
+              "!GetAZs"
+              "!ImportValue"
+              "!ImportValue sequence"
+              "!Select"
+              "!Select sequence"
+              "!Split"
+              "!Split sequence"
+            ];
+
+            "[yaml]" = { };
+
+            "json.schemas" = [ ];
+
+            "git.autofetch" = true;
+            "githubPullRequests.pullBranch" = "never";
+
+            "eslint.workingDirectories" = [ { "mode" = "auto"; } ];
           };
 
-          "gopls" = {
-            "buildFlags" = [ ];
-            # // Add parameter placeholders when completing a function.
-            "usePlaceholders" = true;
-            # // If true; enable additional analyses with staticcheck.
-            # // Warning = This will significantly increase memory usage.
-            "staticcheck" = false;
-            "analyses" = {
-              "fillstruct" = false;
-            };
-          };
+          extensions = (
+            with pkgs.vscode-extensions;
+            [
+              # asvetliakov.vscode-neovim
 
-          "[html]" = {
-            "editor.defaultFormatter" = "vscode.html-language-features";
-          };
+              bradlc.vscode-tailwindcss
 
-          "[json]" = {
-            "editor.defaultFormatter" = "vscode.json-language-features";
-          };
+              catppuccin.catppuccin-vsc
 
-          "[jsonc]" = {
-            "editor.defaultFormatter" = "esbenp.prettier-vscode";
-          };
+              dbaeumer.vscode-eslint
 
-          "[graphql]" = {
-            "editor.formatOnSave" = false;
-          };
+              github.vscode-pull-request-github
 
-          "editor.suggestSelection" = "first";
-          "editor.fontLigatures" = true;
-          "editor.wordWrap" = "on";
-          "editor.tabSize" = 2;
-          "editor.unicodeHighlight.invisibleCharacters" = false;
-          "editor.formatOnSave" = true;
-          # "editor.fontSize" = 11;
+              eamodio.gitlens
 
-          "vsintellicode.modify.editor.suggestSelection" = "automaticallyOverrodeDefaultValue";
+              esbenp.prettier-vscode
 
-          "search.exclude" = {
-            "**/node_modules" = false;
-            "**/bower_components" = true;
-            "**/*.code-search" = true;
-          };
+              golang.go
 
-          "gitlens.hovers.currentLine.over" = "line";
-          "diffEditor.ignoreTrimWhitespace" = true;
+              graphql.vscode-graphql
+              #graphql.vscode-graphql-execution
+              graphql.vscode-graphql-syntax
 
-          "yaml.customTags" = [
-            "!And"
-            "!And sequence"
-            "!If"
-            "!If sequence"
-            "!Not"
-            "!Not sequence"
-            "!Equals"
-            "!Equals sequence"
-            "!Or"
-            "!Or sequence"
-            "!FindInMap"
-            "!FindInMap sequence"
-            "!Base64"
-            "!Join"
-            "!Join sequence"
-            "!Cidr"
-            "!Ref"
-            "!Sub"
-            "!Sub sequence"
-            "!GetAtt"
-            "!GetAZs"
-            "!ImportValue"
-            "!ImportValue sequence"
-            "!Select"
-            "!Select sequence"
-            "!Split"
-            "!Split sequence"
-          ];
+              hashicorp.terraform
 
-          "[yaml]" = { };
+              jnoortheen.nix-ide
+              mathiasfrohlich.kotlin
 
-          "json.schemas" = [ ];
+              ms-azuretools.vscode-docker
 
-          "git.autofetch" = true;
-          "githubPullRequests.pullBranch" = "never";
+              ms-kubernetes-tools.vscode-kubernetes-tools
 
-          "eslint.workingDirectories" = [ { "mode" = "auto"; } ];
+              ms-vscode.makefile-tools
+
+              vscjava.vscode-gradle
+              vscjava.vscode-java-debug
+              vscjava.vscode-java-dependency
+              vscjava.vscode-java-test
+              vscjava.vscode-maven
+
+              redhat.java
+              redhat.vscode-yaml
+
+              # vscjava.vscode-java-pack
+              zxh404.vscode-proto3
+            ]
+          );
         };
-
-        extensions = (
-          with pkgs.vscode-extensions;
-          [
-            # asvetliakov.vscode-neovim
-
-            bradlc.vscode-tailwindcss
-
-            catppuccin.catppuccin-vsc
-
-            dbaeumer.vscode-eslint
-
-            github.vscode-pull-request-github
-
-            eamodio.gitlens
-
-            esbenp.prettier-vscode
-
-            golang.go
-
-            graphql.vscode-graphql
-            #graphql.vscode-graphql-execution
-            graphql.vscode-graphql-syntax
-
-            hashicorp.terraform
-
-            jnoortheen.nix-ide
-            mathiasfrohlich.kotlin
-
-            ms-azuretools.vscode-docker
-
-            ms-kubernetes-tools.vscode-kubernetes-tools
-
-            ms-vscode.makefile-tools
-
-            vscjava.vscode-gradle
-            vscjava.vscode-java-debug
-            vscjava.vscode-java-dependency
-            vscjava.vscode-java-test
-            vscjava.vscode-maven
-
-            redhat.java
-            redhat.vscode-yaml
-
-            # vscjava.vscode-java-pack
-            zxh404.vscode-proto3
-          ]
-        );
       };
     };
   };

--- a/modules/home/vscode/default.nix
+++ b/modules/home/vscode/default.nix
@@ -6,7 +6,8 @@
 {
   programs = {
     vscode = {
-      enable = true;
+      # Disabled: config retained, package not installed. Flip to true to reinstate.
+      enable = false;
       package = pkgs.vscode;
 
       profiles.default = {

--- a/modules/home/waybar/default.nix
+++ b/modules/home/waybar/default.nix
@@ -125,6 +125,27 @@ in
 {
   options.${namespace}.waybar = {
     enable = lib.mkEnableOption "waybar";
+
+    timezone = lib.mkOption {
+      type = lib.types.nullOr lib.types.str;
+      default = null;
+      description = "Clock timezone; null = system local time.";
+    };
+
+    thermalZone = lib.mkOption {
+      type = lib.types.int;
+      default = 2;
+      description = "Thermal zone index used by the temperature module.";
+    };
+
+    hwmonPaths = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [
+        "/sys/class/hwmon/hwmon1/temp1_input"
+        "/sys/class/hwmon/hwmon2/temp1_input"
+      ];
+      description = "hwmon paths used by the temperature module.";
+    };
   };
 
   config = lib.mkIf cfg.enable {
@@ -213,25 +234,28 @@ in
           };
 
           # Clock
-          clock = {
-            timezone = "America/Vancouver";
-            tooltip-format = "<big>{:%Y %B}</big>\n<tt><small>{calendar}</small></tt>";
-            format = "{:%H:%M}";
-            format-alt = "{:%a, %b %d, %Y}";
-            calendar = {
-              mode = "year";
-              mode-mon-col = 3;
-              weeks-pos = "right";
-              on-scroll = 1;
-              format = {
-                months = "<span color='#c6a0f6'><b>{}</b></span>";
-                days = "<span color='#cad3f5'><b>{}</b></span>";
-                weeks = "<span color='#8bd5ca'><b>W{}</b></span>";
-                weekdays = "<span color='#f5a97f'><b>{}</b></span>";
-                today = "<span color='#ed8796'><b><u>{}</u></b></span>";
+          clock =
+            lib.optionalAttrs (cfg.timezone != null) {
+              timezone = cfg.timezone;
+            }
+            // {
+              tooltip-format = "<big>{:%Y %B}</big>\n<tt><small>{calendar}</small></tt>";
+              format = "{:%H:%M}";
+              format-alt = "{:%a, %b %d, %Y}";
+              calendar = {
+                mode = "year";
+                mode-mon-col = 3;
+                weeks-pos = "right";
+                on-scroll = 1;
+                format = {
+                  months = "<span color='#c6a0f6'><b>{}</b></span>";
+                  days = "<span color='#cad3f5'><b>{}</b></span>";
+                  weeks = "<span color='#8bd5ca'><b>W{}</b></span>";
+                  weekdays = "<span color='#f5a97f'><b>{}</b></span>";
+                  today = "<span color='#ed8796'><b><u>{}</u></b></span>";
+                };
               };
             };
-          };
 
           # CPU usage
           cpu = {
@@ -257,11 +281,8 @@ in
 
           # Temperature monitoring
           temperature = {
-            thermal-zone = 2;
-            hwmon-path = [
-              "/sys/class/hwmon/hwmon1/temp1_input"
-              "/sys/class/hwmon/hwmon2/temp1_input"
-            ];
+            thermal-zone = cfg.thermalZone;
+            hwmon-path = cfg.hwmonPaths;
             critical-threshold = 80;
             format-critical = "󰸁 {temperatureC}°C";
             format = "󰔏 {temperatureC}°C";

--- a/modules/home/waybar/default.nix
+++ b/modules/home/waybar/default.nix
@@ -7,6 +7,120 @@
 }:
 let
   cfg = config.${namespace}.waybar;
+
+  vpnControl = pkgs.writeShellApplication {
+    name = "waybar-vpn-control";
+    runtimeInputs = with pkgs; [
+      iproute2
+      libnotify
+      coreutils
+      util-linux
+    ];
+    text = ''
+      set -u
+      ACTION="''${1:-status}"
+      FLAG_DIR="''${XDG_RUNTIME_DIR:-/tmp}"
+      FAIL_FLAG="$FLAG_DIR/waybar-vpn-failed"
+      PID_FLAG="$FLAG_DIR/waybar-vpn-connecting.pid"
+      LOG_FILE="$FLAG_DIR/waybar-vpn.log"
+      BUDGET=120
+      # sudo'd commands must use these exact paths: the NOPASSWD sudoers rules
+      # match on them, and sudo (NixOS sets no secure_path) would otherwise
+      # resolve PATH to /nix/store binaries and demand a password — which fails
+      # silently under waybar's TTY-less exec.
+      SYSTEMCTL=/run/current-system/sw/bin/systemctl
+      WG=/run/current-system/sw/bin/wg
+
+      is_up() {
+        ip link show wg0 >/dev/null 2>&1 || return 1
+        # Interface exists but verify a handshake actually completed
+        local ts
+        ts=$(sudo "$WG" show wg0 latest-handshakes 2>/dev/null | head -1 | cut -f2)
+        [ -n "$ts" ] && [ "$ts" != "0" ]
+      }
+
+      connecting_pid() {
+        [ -f "$PID_FLAG" ] || return 1
+        local pid
+        pid=$(cat "$PID_FLAG" 2>/dev/null) || return 1
+        [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null && echo "$pid"
+      }
+
+      kill_connect() {
+        local pid
+        pid=$(connecting_pid) && kill -- "-$pid" 2>/dev/null
+        rm -f "$PID_FLAG"
+        timeout 5 sudo "$SYSTEMCTL" stop wg-quick-wg0.service 2>/dev/null || true
+      }
+
+      case "$ACTION" in
+        status)
+          if [ -f "$FAIL_FLAG" ]; then
+            printf '%s\n' '{"text": "󱎘", "tooltip": "VPN disabled — right-click to reset", "class": "failed"}'
+          elif connecting_pid >/dev/null; then
+            printf '%s\n' '{"text": "󱎫", "tooltip": "VPN connecting… click to cancel", "class": "connecting"}'
+          elif is_up; then
+            printf '%s\n' '{"text": "󰌾", "tooltip": "VPN connected (wg0)", "class": "connected"}'
+          else
+            printf '%s\n' '{"text": "󰿆", "tooltip": "VPN disconnected", "class": "disconnected"}'
+          fi
+          ;;
+        toggle)
+          if [ -f "$FAIL_FLAG" ]; then
+            : # disabled — use right-click to reset
+          elif connecting_pid >/dev/null; then
+            kill_connect
+            notify-send -a vpn -t 3000 "VPN" "Cancelled" || true
+          elif is_up; then
+            sudo "$SYSTEMCTL" stop wg-quick-wg0.service
+            rm -f "$PID_FLAG" "$FAIL_FLAG"
+          else
+            setsid -f "$0" connect >>"$LOG_FILE" 2>&1
+          fi
+          ;;
+        reset)
+          kill_connect
+          rm -f "$FAIL_FLAG" "$PID_FLAG"
+          notify-send -a vpn -t 3000 "VPN" "Reset — ready to connect" || true
+          ;;
+        connect)
+          if connecting_pid >/dev/null; then exit 0; fi
+          echo $$ > "$PID_FLAG"
+          trap 'rm -f "$PID_FLAG"' EXIT
+          rm -f "$FAIL_FLAG"
+
+          notify-send -a vpn -t 3000 "VPN" "Connecting…" || true
+
+          SECONDS=0
+          delays=(5 10 20 30 30 30)
+          attempt=0
+          for delay in "''${delays[@]}"; do
+            if [ "$SECONDS" -ge "$BUDGET" ]; then break; fi
+            attempt=$((attempt + 1))
+            timeout 15 sudo "$SYSTEMCTL" start wg-quick-wg0.service 2>/dev/null || true
+            sleep 2
+            if is_up; then
+              notify-send -a vpn -t 3000 "VPN" "Connected" || true
+              exit 0
+            fi
+            timeout 5 sudo "$SYSTEMCTL" stop wg-quick-wg0.service 2>/dev/null || true
+            echo "[$(date -Iseconds)] attempt $attempt failed; sleeping ''${delay}s" >&2
+            sleep "$delay"
+          done
+
+          timeout 5 sudo "$SYSTEMCTL" stop wg-quick-wg0.service 2>/dev/null || true
+          touch "$FAIL_FLAG"
+          notify-send -a vpn -u critical -t 8000 \
+            "VPN" "Connection failed — button disabled. Right-click to reset." || true
+          exit 1
+          ;;
+        *)
+          echo "usage: $(basename "$0") {status|toggle|connect|reset}" >&2
+          exit 2
+          ;;
+      esac
+    '';
+  };
 in
 {
   options.${namespace}.waybar = {
@@ -21,23 +135,24 @@ in
       # Use external configuration files for better maintainability
       settings = {
         mainBar = {
-          # Waybar configuration for Hyprland + Stylix + Catppuccin Mocha
+          # Macchiato-glass three-island bar: workspaces+window | clock | system
           layer = "top";
           position = "top";
-          height = 35;
-          spacing = 4;
+          height = 34;
+          spacing = 0;
           margin-top = 10;
-          margin-left = 15;
-          margin-right = 15;
+          margin-left = 16;
+          margin-right = 16;
           margin-bottom = 0;
 
           # Module layout
           modules-left = [
             "hyprland/workspaces"
             "hyprland/submap"
+            "hyprland/window"
           ];
           modules-center = [
-            "hyprland/window"
+            "clock"
           ];
           modules-right = [
             "tray"
@@ -49,47 +164,38 @@ in
             "memory"
             "temperature"
             "battery"
-            "clock"
           ];
 
-          # Hyprland workspaces
+          # Hyprland workspaces — icons keyed by the named workspaces
+          # (term/ide/browser/social) with a dot fallback for numbered ones
           "hyprland/workspaces" = {
             disable-scroll = true;
             all-outputs = true;
             warp-on-scroll = false;
             format = "{icon}";
             format-icons = {
-              "1" = "󰲠";
-              "2" = "󰲢";
-              "3" = "󰲤";
-              "4" = "󰲦";
-              "5" = "󰲨";
-              "6" = "󰲪";
-              "7" = "󰲬";
-              "8" = "󰲮";
-              "9" = "󰲰";
-              "10" = "󰿬";
+              term = "";
+              ide = "󰅩";
+              browser = "󰇧";
+              social = "󰭹";
               urgent = "󰀪";
-              active = "󰮯";
               default = "󰧞";
-            };
-            persistent-workspaces = {
-              "*" = 5;
             };
           };
 
           # Hyprland window title
           "hyprland/window" = {
             format = "{}";
-            max-length = 60;
+            max-length = 40;
             separate-outputs = true;
             rewrite = {
               "(.*) — Mozilla Firefox" = "󰈹 $1";
-              "(.*) - Visual Studio Code" = "󰨞 $1";
+              "(.*) - Brave" = "󰇧 $1";
+              "(.*) — Zed" = "󰅩 $1";
               "(.*) - vim" = " $1";
               "(.*) - nvim" = " $1";
-              "(.*)Spotify" = "󰓇 $1";
-              "(.*) - Discord" = "󰙯 $1";
+              "(.*) - Slack" = "󰒱 $1";
+              "(.*) - Obsidian(.*)" = "󱓧 $1";
             };
           };
 
@@ -240,29 +346,21 @@ in
             tooltip-format-deactivated = "Idle inhibitor is inactive";
           };
 
-          # WireGuard VPN toggle
+          # WireGuard VPN toggle with backoff retry and auto-disable on failure
           "custom/vpn" = {
             format = "{}";
-            interval = 5;
-            exec = ''
-              if ip link show wg0 &>/dev/null; then
-                echo '{"text": "󰌾", "tooltip": "VPN Connected (wg0)", "class": "connected"}'
-              else
-                echo '{"text": "󰿆", "tooltip": "VPN Disconnected", "class": "disconnected"}'
-              fi
-            '';
+            interval = 2;
+            exec = "${vpnControl}/bin/waybar-vpn-control status";
             return-type = "json";
-            on-click = ''
-              if ip link show wg0 &>/dev/null; then
-                sudo systemctl stop wg-quick-wg0.service
-              else
-                sudo systemctl start wg-quick-wg0.service
-              fi
-            '';
+            on-click = "${vpnControl}/bin/waybar-vpn-control toggle";
+            on-click-right = "${vpnControl}/bin/waybar-vpn-control reset";
           };
         };
       };
 
+      # Macchiato-glass: transparent bar, three frosted islands (Hyprland
+      # layer_rule blurs the waybar namespace), state-only colors, gradient
+      # reserved for the active workspace. Numerals set in IntoneMono.
       style = ''
         /* Catppuccin Macchiato Palette */
         @define-color base #24273a;
@@ -290,39 +388,43 @@ in
         @define-color rosewater #f4dbd6;
 
         * {
-          font-family: "Ubuntu Sans", "Ubuntu", "Font Awesome 6 Free", sans-serif;
-          font-size: 14px;
+          font-family: "Ubuntu Sans", "Symbols Nerd Font", "Font Awesome 6 Free", sans-serif;
+          font-size: 13px;
           font-weight: 600;
           min-height: 0;
         }
 
         window#waybar {
           background: transparent;
+          color: @text;
         }
 
-        window#waybar > box {
-          background: alpha(@base, 0.85);
-          border: 2px solid alpha(@surface1, 0.8);
-          border-radius: 16px;
-          margin: 0;
-          padding: 0 8px;
+        /* Glass islands */
+        .modules-left,
+        .modules-center,
+        .modules-right {
+          background: alpha(@mantle, 0.72);
+          border: 1px solid alpha(@surface1, 0.55);
+          border-radius: 17px;
+          padding: 0 6px;
         }
 
         tooltip {
-          background: @mantle;
-          border: 2px solid @mauve;
+          background: alpha(@crust, 0.95);
+          border: 1px solid alpha(@surface1, 0.8);
           border-radius: 12px;
         }
 
         tooltip label {
           color: @text;
-          padding: 4px 8px;
+          padding: 6px 10px;
         }
 
-        /* Module styling */
-        #workspaces,
+        /* Quiet module baseline — pills appear only for state */
         #window,
+        #submap,
         #tray,
+        #custom-vpn,
         #idle_inhibitor,
         #pulseaudio,
         #network,
@@ -331,70 +433,79 @@ in
         #temperature,
         #battery,
         #clock {
-          padding: 4px 12px;
-          margin: 4px 2px;
-          border-radius: 10px;
-          background: alpha(@surface0, 0.6);
-          color: @text;
-          transition: all 0.3s ease;
+          background: transparent;
+          color: @subtext1;
+          padding: 2px 10px;
+          margin: 3px 1px;
+          border-radius: 999px;
+          transition: background-color 0.2s ease, color 0.2s ease;
+        }
+
+        /* Mono numerals for the system cluster and clock */
+        #pulseaudio,
+        #network,
+        #cpu,
+        #memory,
+        #temperature,
+        #battery,
+        #clock {
+          font-family: "IntoneMono Nerd Font Mono", "IntoneMono Nerd Font", "Ubuntu Sans", monospace;
+          font-weight: 500;
         }
 
         /* Workspaces */
         #workspaces {
           background: transparent;
-          padding: 0;
-          margin: 4px 4px;
+          padding: 0 2px;
+          margin: 3px 0;
         }
 
         #workspaces button {
-          padding: 4px 8px;
+          padding: 2px 10px;
           margin: 0 2px;
-          border-radius: 8px;
-          background: alpha(@surface0, 0.5);
-          color: @subtext0;
+          border-radius: 999px;
+          background: transparent;
+          color: alpha(@subtext0, 0.75);
           border: none;
-          transition: all 0.3s ease;
+          font-size: 15px;
+          transition: background-color 0.2s ease, color 0.2s ease;
         }
 
         #workspaces button:hover {
-          background: alpha(@surface1, 0.8);
+          background: alpha(@surface0, 0.85);
           color: @text;
         }
 
         #workspaces button.active {
-          background: linear-gradient(135deg, alpha(@mauve, 0.8), alpha(@lavender, 0.6));
-          color: @base;
-          font-weight: 800;
-          text-shadow: 0 0 2px alpha(@base, 0.3);
+          background: linear-gradient(135deg, alpha(@mauve, 0.95), alpha(@teal, 0.8), alpha(@blue, 0.95));
+          color: @crust;
+          padding: 2px 16px;
         }
 
         #workspaces button.urgent {
           background: linear-gradient(135deg, @red, @maroon);
-          color: @base;
+          color: @crust;
           animation: pulse 1s ease-in-out infinite;
         }
 
         @keyframes pulse {
           0% { opacity: 1; }
-          50% { opacity: 0.7; }
+          50% { opacity: 0.65; }
           100% { opacity: 1; }
         }
 
         /* Window title */
         #window {
-          color: @lavender;
+          color: @subtext0;
           font-weight: 500;
-          background: alpha(@surface0, 0.4);
         }
 
-        /* Submap */
+        /* Submap — the one loud element besides the active workspace */
         #submap {
-          padding: 4px 14px;
-          margin: 4px 2px;
-          border-radius: 10px;
           background: linear-gradient(135deg, @mauve, @pink);
-          color: @base;
+          color: @crust;
           font-weight: 800;
+          padding: 2px 14px;
           animation: breathe 2s ease-in-out infinite;
         }
 
@@ -404,9 +515,17 @@ in
           100% { opacity: 1; }
         }
 
+        /* Clock — center island */
+        #clock {
+          color: @mauve;
+          font-weight: 700;
+          font-size: 14px;
+          padding: 2px 18px;
+        }
+
         /* System tray */
         #tray {
-          background: alpha(@surface0, 0.4);
+          padding: 2px 8px;
         }
 
         #tray > .passive {
@@ -415,164 +534,48 @@ in
 
         #tray > .needs-attention {
           -gtk-icon-effect: highlight;
-          background: alpha(@red, 0.3);
-        }
-
-        /* Idle inhibitor */
-        #idle_inhibitor {
-          color: @subtext0;
-          background: alpha(@surface0, 0.4);
-        }
-
-        #idle_inhibitor.activated {
-          color: @green;
-          background: alpha(@green, 0.2);
-        }
-
-        /* VPN */
-        #custom-vpn {
-          color: @subtext0;
-          background: alpha(@surface0, 0.4);
-          padding: 4px 12px;
-          margin: 4px 2px;
-          border-radius: 10px;
-          transition: all 0.3s ease;
-        }
-
-        #custom-vpn.connected {
-          color: @green;
-          background: alpha(@green, 0.2);
-        }
-
-        #custom-vpn.disconnected {
-          color: @surface2;
-          background: alpha(@surface0, 0.4);
-        }
-
-        #custom-vpn:hover {
-          background: alpha(@surface1, 0.8);
-        }
-
-        /* Clock */
-        #clock {
-          color: @rosewater;
-          background: linear-gradient(135deg, alpha(@mauve, 0.3), alpha(@surface0, 0.6));
-          font-weight: 700;
-          padding: 4px 16px;
-        }
-
-        /* CPU */
-        #cpu {
-          color: @blue;
-          background: alpha(@blue, 0.15);
-        }
-
-        #cpu.warning {
-          color: @yellow;
-          background: alpha(@yellow, 0.2);
-        }
-
-        #cpu.critical {
-          color: @red;
-          background: alpha(@red, 0.2);
-          animation: pulse 1s ease-in-out infinite;
-        }
-
-        /* Memory */
-        #memory {
-          color: @green;
-          background: alpha(@green, 0.15);
-        }
-
-        #memory.warning {
-          color: @yellow;
-          background: alpha(@yellow, 0.2);
-        }
-
-        #memory.critical {
-          color: @red;
-          background: alpha(@red, 0.2);
-          animation: pulse 1s ease-in-out infinite;
-        }
-
-        /* Temperature */
-        #temperature {
-          color: @yellow;
-          background: alpha(@yellow, 0.15);
-        }
-
-        #temperature.critical {
-          color: @red;
           background: alpha(@red, 0.25);
-          animation: pulse 0.8s ease-in-out infinite;
+          border-radius: 999px;
         }
 
-        /* Network */
-        #network {
-          color: @teal;
-          background: alpha(@teal, 0.15);
-        }
+        /* State colors only */
+        #custom-vpn.connected { color: @teal; }
+        #custom-vpn.connecting { color: @peach; }
+        #custom-vpn.disconnected { color: alpha(@subtext0, 0.5); }
+        #custom-vpn.failed { color: @red; }
 
-        #network.disconnected {
-          color: @surface2;
-          background: alpha(@surface0, 0.4);
-        }
+        #idle_inhibitor.activated { color: @peach; }
 
-        #network.linked {
-          color: @yellow;
-          background: alpha(@yellow, 0.15);
-        }
+        #pulseaudio.muted { color: alpha(@subtext0, 0.5); }
+        #pulseaudio.bluetooth { color: @blue; }
 
-        /* Audio */
-        #pulseaudio {
-          color: @peach;
-          background: alpha(@peach, 0.15);
-        }
+        #network.disconnected { color: @red; }
+        #network.linked { color: @yellow; }
 
-        #pulseaudio.muted {
-          color: @surface2;
-          background: alpha(@surface0, 0.4);
-        }
-
-        #pulseaudio.bluetooth {
-          color: @blue;
-          background: alpha(@blue, 0.15);
-        }
-
-        /* Battery */
-        #battery {
-          color: @green;
-          background: alpha(@green, 0.15);
-        }
-
-        #battery.good {
-          color: @green;
-          background: alpha(@green, 0.15);
-        }
-
+        #cpu.warning,
+        #memory.warning,
         #battery.warning:not(.charging) {
           color: @yellow;
-          background: alpha(@yellow, 0.2);
+          background: alpha(@yellow, 0.15);
         }
 
+        #cpu.critical,
+        #memory.critical,
+        #temperature.critical,
         #battery.critical:not(.charging) {
           color: @red;
-          background: linear-gradient(135deg, alpha(@red, 0.3), alpha(@maroon, 0.2));
+          background: alpha(@red, 0.18);
           animation: pulse 1s ease-in-out infinite;
         }
 
-        #battery.charging {
-          color: @green;
-          background: alpha(@green, 0.2);
-        }
-
+        #battery.charging,
         #battery.plugged {
-          color: @teal;
-          background: alpha(@teal, 0.15);
+          color: @green;
         }
 
-        /* Hover effects for all modules */
+        /* Hover */
         #tray:hover,
+        #custom-vpn:hover,
         #idle_inhibitor:hover,
         #pulseaudio:hover,
         #network:hover,
@@ -581,8 +584,8 @@ in
         #temperature:hover,
         #battery:hover,
         #clock:hover {
-          background: alpha(@surface1, 0.8);
-          border-radius: 10px;
+          background: alpha(@surface0, 0.8);
+          color: @text;
         }
       '';
     };

--- a/modules/home/zed/default.nix
+++ b/modules/home/zed/default.nix
@@ -4,1239 +4,1251 @@
 # See [[architecture]] for how this fits into the home-manager module tree.
 {
   lib,
+  config,
   namespace,
   pkgs,
   ...
 }:
+let
+  cfg = config.${namespace}.zed;
+in
 {
-  programs.zed-editor = {
-    enable = true;
-    package = pkgs.zed-editor;
-    installRemoteServer = true;
-    extraPackages = [ pkgs.nixd ];
+  options.${namespace}.zed = {
+    enable = lib.mkEnableOption "zed" // {
+      default = true;
+    };
+  };
 
-    themes = { };
-    userKeymaps = [ ];
-    userTasks = [ ];
+  config = lib.mkIf cfg.enable {
+    programs.zed-editor = {
+      enable = true;
+      package = pkgs.zed-editor;
+      installRemoteServer = true;
+      extraPackages = [ pkgs.nixd ];
 
-    # Extensions organized by category
-    extensions = [
-      # Icons
-      "bearded-icon-theme"
-      "catppuccin-icons"
-      "charmed-icons"
-      "chawyehsu-vscode-icons"
-      "clean-vscode-icons"
-      "colored-zed-icons-theme"
-      "icons-modern-material"
-      "jetbrains-icons"
-      "jetbrains-new-ui-icons"
-      "material-icon-theme"
-      "modern-icons"
-      "monospace-icon-theme"
-      "openmoji-icons"
-      "phosphor-icons-theme"
-      "seti-icons"
-      "symbols"
-      "vscode-icons"
-      "vscode-great-icons"
+      themes = { };
+      userKeymaps = [ ];
+      userTasks = [ ];
 
-      # Language Support
-      "assembly"
-      "biome"
-      "csv"
-      "dart"
-      "deno"
-      "flatbuffers"
-      "graphql"
-      "html"
-      "ini"
-      "java"
-      "kotlin"
-      "nix"
-      "proto"
-      "sql"
-      "toml"
-      "xml"
-      "zig"
+      # Extensions organized by category
+      extensions = [
+        # Icons
+        "bearded-icon-theme"
+        "catppuccin-icons"
+        "charmed-icons"
+        "chawyehsu-vscode-icons"
+        "clean-vscode-icons"
+        "colored-zed-icons-theme"
+        "icons-modern-material"
+        "jetbrains-icons"
+        "jetbrains-new-ui-icons"
+        "material-icon-theme"
+        "modern-icons"
+        "monospace-icon-theme"
+        "openmoji-icons"
+        "phosphor-icons-theme"
+        "seti-icons"
+        "symbols"
+        "vscode-icons"
+        "vscode-great-icons"
 
-      # Development Tools
-      "docker-compose"
-      "dockerfile"
-      "git-firefly"
-      "golangci-lint"
-      "helm"
-      "http"
-      "make"
-      "nginx"
-      "terraform"
-      "tmux"
+        # Language Support
+        "assembly"
+        "biome"
+        "csv"
+        "dart"
+        "deno"
+        "flatbuffers"
+        "graphql"
+        "html"
+        "ini"
+        "java"
+        "kotlin"
+        "nix"
+        "proto"
+        "sql"
+        "toml"
+        "xml"
+        "zig"
 
-      # Utilities
-      "brainfuck"
-      "log"
-      "mermaid"
-      "perplexity"
+        # Development Tools
+        "docker-compose"
+        "dockerfile"
+        "git-firefly"
+        "golangci-lint"
+        "helm"
+        "http"
+        "make"
+        "nginx"
+        "terraform"
+        "tmux"
 
-      # Themes
-      "0x96f"
-      "0xtz"
-      "1984-theme"
-      "adaltas-theme"
-      "adech"
-      "adwaita"
-      "adwaita-pastel"
-      "aesthetic-theme"
-      "alabaster"
-      "alabaster-dark"
-      "amber-monochrome-monitor-crt-phosphor"
-      "andromeda"
-      "anthracite-theme"
-      "anya"
-      "anysphere-theme"
-      "apisartisan"
-      "aquarium-theme"
-      "arctic-depth"
-      "ariake"
-      "asteroid"
-      "atomize"
-      "axolosin"
-      "aylin-theme"
-      "aystra"
-      "ayu-darker"
-      "azutiku-theme"
-      "bamboo-theme"
-      "barbenheimer"
-      "base16"
-      "batman"
-      "beanseeds-pro"
-      "bearded"
-      "becker-theme"
-      "blackfox"
-      "blackrain-theme"
-      "blackula"
-      "blade-runner-2049"
-      "blanche"
-      "blankeos-zen"
-      "blinds-theme"
-      "bluloco-theme"
-      "brook-code-theme"
-      "bubblegum"
-      "call-trans-opt-received"
-      "catbox"
-      "catppuccin"
-      "catppuccin-blur"
-      "catppuccin-blur-plus"
-      "chai-theme"
-      "chanterelle"
-      "chaos-theory-theme"
-      "chatgpt"
-      "chocolate"
-      "cisco-theme"
-      "city-lights"
-      "claude-code-inspired-dark"
-      "cobalt2"
-      "codely-theme"
-      "codesandbox-theme"
-      "codestackr"
-      "colorizer"
-      "cosmos"
-      "crimson-theme"
-      "crystal-theme"
-      "cursor"
-      "cyan-light-theme"
-      "darcula-dark"
-      "darcula-dark-okkano"
-      "dark-discord"
-      "dark-material-dracula"
-      "dark-pop-ui"
-      "darker-horizon"
-      "darkmatter-theme"
-      "day-shift"
-      "decorative-stitch"
-      "denix"
-      "dogi"
-      "dracula"
-      "dram"
-      "dream"
-      "dune-theme"
-      "eiffel-theme"
-      "elderberry"
-      "ember-theme"
-      "emerald-night"
-      "everforest"
-      "everforest-theme"
-      "evil-rabbit-theme"
-      "exquisite"
-      "eyecandy"
-      "ezio-theme"
-      "flat-theme"
-      "fleet-themes"
-      "fleeting-theme"
-      "fleury"
-      "flexoki-themes"
-      "focus-theme"
-      "forest-night"
-      "frosted-theme"
-      "gafelson"
-      "gentle-dark"
-      "github-classic"
-      "github-copilot-theme"
-      "github-dark-default"
-      "github-monochrome-theme"
-      "github-plus-theme"
-      "github-theme"
-      "glazier"
-      "gleam-theme"
-      "graphene"
-      "green-monochrome-monitor-crt-phosphor"
-      "grey-theme"
-      "gruber-darker"
-      "gruber-flavors"
-      "gruvbox-baby"
-      "gruvbox-crisp-themes"
-      "gruvbox-ish"
-      "gruvbox-material"
-      "gruvchad"
-      "hacker-night-vision"
-      "hacker-theme"
-      "haku-dark-theme"
-      "halcyon"
-      "hami-melon-theme"
-      "hex-light-theme"
-      "hivacruz-theme"
-      "horizon"
-      "horizon-extended"
-      "hot-dog-stand"
-      "ibm-5151"
-      "iceberg"
-      "iceicebergy"
-      "indigo"
-      "intellij-newui-theme"
-      "ir-black"
-      "jellybeans-vim"
-      "jetbrains-darcula-theme-by-bronya0"
-      "jetbrains-rider"
-      "jetbrains-themes"
-      "kanagawa-themes"
-      "kanso"
-      "kiro"
-      "kiselevka"
-      "ktrz-monokai"
-      "kubesong"
-      "leblackque"
-      "lights-out"
-      "lonely-planet"
-      "lotus-theme"
-      "lusch-theme"
-      "lydia"
-      "macos-classic"
-      "malibu"
-      "maple-theme"
-      "marble"
-      "mariana-theme"
-      "marine-dark"
-      "martianized"
-      "material-dark"
-      "material-theme"
-      "matte-black"
-      "mau"
-      "maya"
-      "melange"
-      "mellow"
-      "min-theme"
-      "min-theme-plus"
-      "mint-theme"
-      "mnemonic"
-      "modest-dark"
-      "modus-themes"
-      "molten-theme"
-      "monokai-nebula"
-      "monokai-night"
-      "monokai-og"
-      "monokai-reversed"
-      "monokai-vibrant-amped"
-      "monolith"
-      "monosami"
-      "monospace-theme"
-      "moonlight"
-      "mosel"
-      "msun-dark"
-      "muted"
-      "nanowise"
-      "napalm"
-      "nebula-pulse"
-      "neo-brutalism"
-      "neon-cyberpunk"
-      "neon-pulse-theme"
-      "neosolarized"
-      "neovim-default"
-      "neutral-theme"
-      "new-darcula"
-      "night-owlz"
-      "night-shift"
-      "nightfox"
-      "nightfox-m"
-      "nixdorf-8870"
-      "nobin-theme"
-      "noctis-port"
-      "noir-and-blanc-theme"
-      "nord"
-      "nordic-nvim-theme"
-      "nordic-theme"
-      "norrsken"
-      "not-material-theme"
-      "nstlgy-dark"
-      "nuisance"
-      "nvim-nightfox"
-      "nyxvamp-theme"
-      "oasis"
-      "obsidian-sunset"
-      "ocean-dark-motifs"
-      "oceanic-next"
-      "oh-lucy"
-      "oldbook-theme"
-      "one-black-theme"
-      "one-dark-darkened"
-      "one-dark-extended"
-      "one-dark-flat"
-      "one-dark-pro"
-      "one-dark-pro-max"
-      "one-dark-pro-monokai-darker"
-      "one-hunter"
-      "one-thing-theme"
-      "onurb"
-      "oolong"
-      "oscura"
-      "outrun"
-      "oxocarbon"
-      "palenight"
-      "panda-theme"
-      "papercolor"
-      "paraiso"
-      "penumbra"
-      "penumbra-plus"
-      "perfect-dusk"
-      "phine-theme"
-      "pinata-theme"
-      "plato-themes"
-      "poimandres"
-      "polar-theme"
-      "popping-and-locking"
-      "purr"
-      "quiet-light-theme"
-      "quill"
-      "railscast"
-      "rainbow"
-      "replicant"
-      "retrofit-theme"
-      "rich-vesper"
-      "rose-pine-theme"
-      "rosevin"
-      "rust-rover-dark-theme"
-      "s-dark-theme"
-      "sequoia"
-      "serendipity"
-      "severance-theme"
-      "shades-of-purple-theme"
-      "short-giraffe-theme"
-      "simple-darker"
-      "siri"
-      "sitruuna"
-      "sl4y-theme"
-      "slate"
-      "smooth"
-      "snazzy"
-      "snow-fox-theme"
-      "snowfall"
-      "snowflake"
-      "solarized"
-      "solarized-fp"
-      "sonokai"
-      "spai-zero-theme"
-      "spiceflow-theme"
-      "srcery"
-      "struct-theme"
-      "sublime-mariana-theme"
-      "subliminal-nightfall"
-      "sumi-light"
-      "sunset-drive"
-      "supaglass"
-      "supergreatmonokai"
-      "syntax"
-      "synthwave"
-      "synthwave-alpha-theme"
-      "t3-theme"
-      "tailwind-theme"
-      "tanuki"
-      "terrible-theme"
-      "the-best-theme"
-      "the-dark-side"
-      "theme-lince"
-      "tm-twilight"
-      "tokyo-night"
-      "tomorrow-min-theme"
-      "tomorrow-night-burns-theme"
-      "tomorrow-theme"
-      "tron-legacy"
-      "tsar"
-      "tsarcasm"
-      "twilight"
-      "ultimate-dark-neo"
-      "umbralkai"
-      "underground-theme"
-      "unoflat"
-      "v0-theme"
-      "vague"
-      "vapor-theme"
-      "vercel-theme"
-      "vesper"
-      "vim-theme"
-      "vintergata"
-      "visual-assist-dark"
-      "vitesse"
-      "vitesse-theme-refined"
-      "vscode-classic-theme"
-      "vscode-dark-high-contrast"
-      "vscode-dark-modern"
-      "vscode-dark-plus"
-      "vscode-dark-polished"
-      "vscode-light-plus"
-      "vscode-monokai-charcoal"
-      "vue-theme"
-      "vynora"
-      "wakfu-theme"
-      "warp-one-dark"
-      "xcode-themes"
-      "xy-zed"
-      "yaka"
-      "yamura"
-      "yellowed"
-      "yue-theme"
-      "yugen"
-      "zed-legacy-themes"
-      "zedburn"
-      "zedokai"
-      "zedokai-darkest-machine"
-      "zedrack-theme"
-      "zedspace"
-      "zedwaita"
-      "zen"
-      "zen-abyssal"
-      "zero-trust-theme"
-      "zoegi-theme"
-    ];
+        # Utilities
+        "brainfuck"
+        "log"
+        "mermaid"
+        "perplexity"
 
-    userSettings = {
-      active_pane_modifiers = {
-        border_size = 0;
-        inactive_opacity = 1;
-      };
-      agent = {
-        default_model = {
-          model = "claude-4-sonnet";
-          provider = "anthropic";
+        # Themes
+        "0x96f"
+        "0xtz"
+        "1984-theme"
+        "adaltas-theme"
+        "adech"
+        "adwaita"
+        "adwaita-pastel"
+        "aesthetic-theme"
+        "alabaster"
+        "alabaster-dark"
+        "amber-monochrome-monitor-crt-phosphor"
+        "andromeda"
+        "anthracite-theme"
+        "anya"
+        "anysphere-theme"
+        "apisartisan"
+        "aquarium-theme"
+        "arctic-depth"
+        "ariake"
+        "asteroid"
+        "atomize"
+        "axolosin"
+        "aylin-theme"
+        "aystra"
+        "ayu-darker"
+        "azutiku-theme"
+        "bamboo-theme"
+        "barbenheimer"
+        "base16"
+        "batman"
+        "beanseeds-pro"
+        "bearded"
+        "becker-theme"
+        "blackfox"
+        "blackrain-theme"
+        "blackula"
+        "blade-runner-2049"
+        "blanche"
+        "blankeos-zen"
+        "blinds-theme"
+        "bluloco-theme"
+        "brook-code-theme"
+        "bubblegum"
+        "call-trans-opt-received"
+        "catbox"
+        "catppuccin"
+        "catppuccin-blur"
+        "catppuccin-blur-plus"
+        "chai-theme"
+        "chanterelle"
+        "chaos-theory-theme"
+        "chatgpt"
+        "chocolate"
+        "cisco-theme"
+        "city-lights"
+        "claude-code-inspired-dark"
+        "cobalt2"
+        "codely-theme"
+        "codesandbox-theme"
+        "codestackr"
+        "colorizer"
+        "cosmos"
+        "crimson-theme"
+        "crystal-theme"
+        "cursor"
+        "cyan-light-theme"
+        "darcula-dark"
+        "darcula-dark-okkano"
+        "dark-discord"
+        "dark-material-dracula"
+        "dark-pop-ui"
+        "darker-horizon"
+        "darkmatter-theme"
+        "day-shift"
+        "decorative-stitch"
+        "denix"
+        "dogi"
+        "dracula"
+        "dram"
+        "dream"
+        "dune-theme"
+        "eiffel-theme"
+        "elderberry"
+        "ember-theme"
+        "emerald-night"
+        "everforest"
+        "everforest-theme"
+        "evil-rabbit-theme"
+        "exquisite"
+        "eyecandy"
+        "ezio-theme"
+        "flat-theme"
+        "fleet-themes"
+        "fleeting-theme"
+        "fleury"
+        "flexoki-themes"
+        "focus-theme"
+        "forest-night"
+        "frosted-theme"
+        "gafelson"
+        "gentle-dark"
+        "github-classic"
+        "github-copilot-theme"
+        "github-dark-default"
+        "github-monochrome-theme"
+        "github-plus-theme"
+        "github-theme"
+        "glazier"
+        "gleam-theme"
+        "graphene"
+        "green-monochrome-monitor-crt-phosphor"
+        "grey-theme"
+        "gruber-darker"
+        "gruber-flavors"
+        "gruvbox-baby"
+        "gruvbox-crisp-themes"
+        "gruvbox-ish"
+        "gruvbox-material"
+        "gruvchad"
+        "hacker-night-vision"
+        "hacker-theme"
+        "haku-dark-theme"
+        "halcyon"
+        "hami-melon-theme"
+        "hex-light-theme"
+        "hivacruz-theme"
+        "horizon"
+        "horizon-extended"
+        "hot-dog-stand"
+        "ibm-5151"
+        "iceberg"
+        "iceicebergy"
+        "indigo"
+        "intellij-newui-theme"
+        "ir-black"
+        "jellybeans-vim"
+        "jetbrains-darcula-theme-by-bronya0"
+        "jetbrains-rider"
+        "jetbrains-themes"
+        "kanagawa-themes"
+        "kanso"
+        "kiro"
+        "kiselevka"
+        "ktrz-monokai"
+        "kubesong"
+        "leblackque"
+        "lights-out"
+        "lonely-planet"
+        "lotus-theme"
+        "lusch-theme"
+        "lydia"
+        "macos-classic"
+        "malibu"
+        "maple-theme"
+        "marble"
+        "mariana-theme"
+        "marine-dark"
+        "martianized"
+        "material-dark"
+        "material-theme"
+        "matte-black"
+        "mau"
+        "maya"
+        "melange"
+        "mellow"
+        "min-theme"
+        "min-theme-plus"
+        "mint-theme"
+        "mnemonic"
+        "modest-dark"
+        "modus-themes"
+        "molten-theme"
+        "monokai-nebula"
+        "monokai-night"
+        "monokai-og"
+        "monokai-reversed"
+        "monokai-vibrant-amped"
+        "monolith"
+        "monosami"
+        "monospace-theme"
+        "moonlight"
+        "mosel"
+        "msun-dark"
+        "muted"
+        "nanowise"
+        "napalm"
+        "nebula-pulse"
+        "neo-brutalism"
+        "neon-cyberpunk"
+        "neon-pulse-theme"
+        "neosolarized"
+        "neovim-default"
+        "neutral-theme"
+        "new-darcula"
+        "night-owlz"
+        "night-shift"
+        "nightfox"
+        "nightfox-m"
+        "nixdorf-8870"
+        "nobin-theme"
+        "noctis-port"
+        "noir-and-blanc-theme"
+        "nord"
+        "nordic-nvim-theme"
+        "nordic-theme"
+        "norrsken"
+        "not-material-theme"
+        "nstlgy-dark"
+        "nuisance"
+        "nvim-nightfox"
+        "nyxvamp-theme"
+        "oasis"
+        "obsidian-sunset"
+        "ocean-dark-motifs"
+        "oceanic-next"
+        "oh-lucy"
+        "oldbook-theme"
+        "one-black-theme"
+        "one-dark-darkened"
+        "one-dark-extended"
+        "one-dark-flat"
+        "one-dark-pro"
+        "one-dark-pro-max"
+        "one-dark-pro-monokai-darker"
+        "one-hunter"
+        "one-thing-theme"
+        "onurb"
+        "oolong"
+        "oscura"
+        "outrun"
+        "oxocarbon"
+        "palenight"
+        "panda-theme"
+        "papercolor"
+        "paraiso"
+        "penumbra"
+        "penumbra-plus"
+        "perfect-dusk"
+        "phine-theme"
+        "pinata-theme"
+        "plato-themes"
+        "poimandres"
+        "polar-theme"
+        "popping-and-locking"
+        "purr"
+        "quiet-light-theme"
+        "quill"
+        "railscast"
+        "rainbow"
+        "replicant"
+        "retrofit-theme"
+        "rich-vesper"
+        "rose-pine-theme"
+        "rosevin"
+        "rust-rover-dark-theme"
+        "s-dark-theme"
+        "sequoia"
+        "serendipity"
+        "severance-theme"
+        "shades-of-purple-theme"
+        "short-giraffe-theme"
+        "simple-darker"
+        "siri"
+        "sitruuna"
+        "sl4y-theme"
+        "slate"
+        "smooth"
+        "snazzy"
+        "snow-fox-theme"
+        "snowfall"
+        "snowflake"
+        "solarized"
+        "solarized-fp"
+        "sonokai"
+        "spai-zero-theme"
+        "spiceflow-theme"
+        "srcery"
+        "struct-theme"
+        "sublime-mariana-theme"
+        "subliminal-nightfall"
+        "sumi-light"
+        "sunset-drive"
+        "supaglass"
+        "supergreatmonokai"
+        "syntax"
+        "synthwave"
+        "synthwave-alpha-theme"
+        "t3-theme"
+        "tailwind-theme"
+        "tanuki"
+        "terrible-theme"
+        "the-best-theme"
+        "the-dark-side"
+        "theme-lince"
+        "tm-twilight"
+        "tokyo-night"
+        "tomorrow-min-theme"
+        "tomorrow-night-burns-theme"
+        "tomorrow-theme"
+        "tron-legacy"
+        "tsar"
+        "tsarcasm"
+        "twilight"
+        "ultimate-dark-neo"
+        "umbralkai"
+        "underground-theme"
+        "unoflat"
+        "v0-theme"
+        "vague"
+        "vapor-theme"
+        "vercel-theme"
+        "vesper"
+        "vim-theme"
+        "vintergata"
+        "visual-assist-dark"
+        "vitesse"
+        "vitesse-theme-refined"
+        "vscode-classic-theme"
+        "vscode-dark-high-contrast"
+        "vscode-dark-modern"
+        "vscode-dark-plus"
+        "vscode-dark-polished"
+        "vscode-light-plus"
+        "vscode-monokai-charcoal"
+        "vue-theme"
+        "vynora"
+        "wakfu-theme"
+        "warp-one-dark"
+        "xcode-themes"
+        "xy-zed"
+        "yaka"
+        "yamura"
+        "yellowed"
+        "yue-theme"
+        "yugen"
+        "zed-legacy-themes"
+        "zedburn"
+        "zedokai"
+        "zedokai-darkest-machine"
+        "zedrack-theme"
+        "zedspace"
+        "zedwaita"
+        "zen"
+        "zen-abyssal"
+        "zero-trust-theme"
+        "zoegi-theme"
+      ];
+
+      userSettings = {
+        active_pane_modifiers = {
+          border_size = 0;
+          inactive_opacity = 1;
         };
-      };
-      # agent_font_size = null;
-      allow_rewrap = "in_comments";
-      always_treat_brackets_as_autoclosed = false;
-      auto_indent = true;
-      auto_indent_on_paste = true;
-      auto_install_extensions = {
-        html = true;
-      };
-      auto_signature_help = false;
-      auto_update = false;
-      auto_update_extensions = { };
-      autosave = "off";
-      autoscroll_on_clicks = false;
-      base_keymap = "VSCode";
-      bottom_dock_layout = "contained";
-      buffer_font_fallbacks = null;
-      buffer_font_family = "IntoneMono Nerd Font Mono";
-      buffer_font_features = null;
-      buffer_font_size = 12;
-      buffer_font_weight = 400;
-      buffer_line_height = "comfortable";
-      calls = {
-        mute_on_join = false;
-        share_on_join = false;
-      };
-      centered_layout = {
-        left_padding = 0.2;
-        right_padding = 0.2;
-      };
-      close_on_file_delete = false;
-      # code_lens = "off";
-      collaboration_panel = {
-        button = false;
-        default_width = 240;
-        dock = "left";
-      };
-      colorize_brackets = false;
-      completions = {
-        lsp = true;
-        lsp_fetch_timeout_ms = 0;
-        lsp_insert_mode = "replace_suffix";
-        words = "fallback";
-        words_min_length = 3;
-      };
-      confirm_quit = false;
-      current_line_highlight = "all";
-      cursor_blink = true;
-      cursor_shape = "bar";
-      debugger = {
-        button = true;
-        dock = "bottom";
-        save_breakpoints = true;
-        stepping_granularity = "line";
-      };
-      diagnostics = {
-        include_warnings = true;
-        inline = {
+        agent = {
+          default_model = {
+            model = "claude-4-sonnet";
+            provider = "anthropic";
+          };
+        };
+        # agent_font_size = null;
+        allow_rewrap = "in_comments";
+        always_treat_brackets_as_autoclosed = false;
+        auto_indent = true;
+        auto_indent_on_paste = true;
+        auto_install_extensions = {
+          html = true;
+        };
+        auto_signature_help = false;
+        auto_update = false;
+        auto_update_extensions = { };
+        autosave = "off";
+        autoscroll_on_clicks = false;
+        base_keymap = "VSCode";
+        bottom_dock_layout = "contained";
+        buffer_font_fallbacks = null;
+        buffer_font_family = "IntoneMono Nerd Font Mono";
+        buffer_font_features = null;
+        buffer_font_size = 12;
+        buffer_font_weight = 400;
+        buffer_line_height = "comfortable";
+        calls = {
+          mute_on_join = false;
+          share_on_join = false;
+        };
+        centered_layout = {
+          left_padding = 0.2;
+          right_padding = 0.2;
+        };
+        close_on_file_delete = false;
+        # code_lens = "off";
+        collaboration_panel = {
+          button = false;
+          default_width = 240;
+          dock = "left";
+        };
+        colorize_brackets = false;
+        completions = {
+          lsp = true;
+          lsp_fetch_timeout_ms = 0;
+          lsp_insert_mode = "replace_suffix";
+          words = "fallback";
+          words_min_length = 3;
+        };
+        confirm_quit = false;
+        current_line_highlight = "all";
+        cursor_blink = true;
+        cursor_shape = "bar";
+        debugger = {
+          button = true;
+          dock = "bottom";
+          save_breakpoints = true;
+          stepping_granularity = "line";
+        };
+        diagnostics = {
+          include_warnings = true;
+          inline = {
+            enabled = false;
+            max_severity = null;
+            min_column = 0;
+            padding = 4;
+            update_debounce_ms = 150;
+          };
+          # primary_only = false;
+          # update_with_cursor = false;
+          # use_rendered = false;
+        };
+        diagnostics_max_severity = null;
+        # diff_view_style = "split";
+        disable_ai = false;
+        # document_folding_ranges = "off";
+        # document_symbols = "off";
+        double_click_in_multibuffer = "select";
+        drag_and_drop_selection = {
+          delay = 300;
+          enabled = true;
+        };
+        drop_target_size = 0.2;
+        edit_predictions = {
+          disabled_globs = [
+            "**/.env*"
+            "**/*.pem"
+            "**/*.key"
+            "**/*.cert"
+            "**/*.crt"
+            "**/.dev.vars"
+            "**/secrets.yml"
+          ];
+        };
+        edit_predictions_disabled_in = [ ];
+        enable_language_server = true;
+        ensure_final_newline_on_save = true;
+        excerpt_context_lines = 2;
+        expand_excerpt_lines = 5;
+        extend_comment_on_newline = true;
+        # extend_list_on_newline = true;
+        fast_scroll_sensitivity = 4;
+        features = {
+          edit_predictions = {
+            provider = "none";
+          };
+        };
+        file_finder = {
+          file_icons = true;
+          modal_max_width = "small";
+          skip_focus_for_active_in_search = true;
+        };
+        file_scan_exclusions = [
+          "**/.git"
+          "**/.svn"
+          "**/.hg"
+          "**/.jj"
+          "**/.sl"
+          "**/.repo"
+          "**/CVS"
+          "**/.DS_Store"
+          "**/Thumbs.db"
+          "**/.classpath"
+          "**/.settings"
+        ];
+        file_scan_inclusions = [ ".env*" ];
+        file_types = {
+          "C" = [
+            "*.c"
+            "*.h"
+          ];
+          "C#" = [ "*.cs" ];
+          "C++" = [
+            "*.cpp"
+            "*.cc"
+            "*.cxx"
+            "*.hpp"
+            "*.hh"
+            "*.hxx"
+          ];
+          "CSS" = [ "*.css" ];
+          "Dart" = [ "*.dart" ];
+          "Dockerfile" = [
+            "Dockerfile*"
+            "*.dockerfile"
+          ];
+          "Go" = [ "*.go" ];
+          "GraphQL" = [
+            "*.graphql"
+            "*.gql"
+          ];
+          "HCL" = [ "*.hcl" ];
+          "HTML" = [
+            "*.html"
+            "*.htm"
+            "*.shtml"
+            "*.xhtml"
+          ];
+          "Java" = [
+            "*.java"
+            "*.jav"
+          ];
+          "JavaScript" = [
+            "*.js"
+            "*.cjs"
+            "*.mjs"
+            "*.jsx"
+          ];
+          "JSONC" = [
+            "**/.zed/**/*.json"
+            "**/zed/**/*.json"
+            "**/Zed/**/*.json"
+            "**/.vscode/**/*.json"
+            "tsconfig.json"
+            "jsconfig.json"
+          ];
+          "Kotlin" = [
+            "*.kt"
+            "*.kts"
+          ];
+          "Lua" = [ "*.lua" ];
+          "Markdown" = [
+            "*.md"
+            "*.markdown"
+          ];
+          "Nix" = [ "*.nix" ];
+          "PHP" = [ "*.php" ];
+          "Proto" = [ "*.proto" ];
+          "Python" = [
+            "*.py"
+            "*.pyi"
+            "SConstruct"
+            "SConscript"
+          ];
+          "Ruby" = [
+            "*.rb"
+            "Rakefile"
+            "Gemfile"
+          ];
+          "Rust" = [ "*.rs" ];
+          "SCSS" = [ "*.scss" ];
+          "Shell Script" = [
+            ".env.*"
+            "*.zsh"
+            "*.bash"
+            "*.sh"
+            "APKBUILD"
+            "PKGBUILD"
+            "*.ebuild"
+            "*.eclass"
+            ".bashrc"
+            ".bash_profile"
+            ".zshrc"
+            ".zprofile"
+          ];
+          "SQL" = [
+            "*.sql"
+            "*.ddl"
+            "*.dml"
+          ];
+          "Swift" = [ "*.swift" ];
+          "Terraform" = [
+            "*.tf"
+            "*.tfvars"
+          ];
+          "TOML" = [ "*.toml" ];
+          "TypeScript" = [
+            "*.ts"
+            "*.cts"
+            "*.mts"
+            "*.tsx"
+          ];
+          "XML" = [
+            "*.xml"
+            "*.xsd"
+            "*.xsl"
+            "*.xslt"
+          ];
+          "YAML" = [
+            "*.yml"
+            "*.yaml"
+          ];
+          "Zig" = [ "*.zig" ];
+        };
+        format_on_save = "on";
+        formatter = "auto";
+        git = {
+          branch_picker = {
+            show_author_name = true;
+          };
+          git_gutter = "tracked_files";
+          gutter_debounce = null;
+          hunk_style = "staged_hollow";
+          inline_blame = {
+            delay_ms = 600;
+            enabled = true;
+            # min_column = 0;
+            # padding = 0;
+            # show_commit_summary = false;
+          };
+          # worktree_directory = "../worktrees";
+        };
+        git_hosting_providers = [ ];
+        git_panel = {
+          button = true;
+          collapse_untracked_diff = false;
+          default_width = 360;
+          dock = "left";
+          fallback_branch_name = "main";
+          scrollbar = {
+            show = null;
+          };
+          sort_by_path = false;
+          status_style = "icon";
+        };
+        global_lsp_settings = {
+          button = true;
+          # notifications = {
+          #   dismiss_timeout_ms = 5000;
+          # };
+          # request_timeout = 120;
+        };
+        go_to_definition_fallback = "find_all_references";
+        # go_to_definition_scroll_strategy = "center";
+        gutter = {
+          breakpoints = true;
+          folds = true;
+          line_numbers = true;
+          min_line_number_digits = 4;
+          runnables = true;
+        };
+        hard_tabs = false;
+        helix_mode = false;
+        hide_mouse = "on_typing_and_movement";
+        horizontal_scroll_margin = 5;
+        hover_popover_delay = 300;
+        hover_popover_enabled = true;
+        # hover_popover_hiding_delay = 300;
+        # hover_popover_sticky = true;
+        icon_theme = {
+          dark = "Zed (Default)";
+          light = "Zed (Default)";
+          mode = "system";
+        };
+        image_viewer = {
+          unit = "binary";
+        };
+        indent_guides = {
+          active_line_width = 1;
+          background_coloring = "disabled";
+          coloring = "fixed";
+          enabled = true;
+          line_width = 1;
+        };
+        # indent_list_on_tab = true;
+        inlay_hints = {
+          edit_debounce_ms = 700;
           enabled = false;
-          max_severity = null;
-          min_column = 0;
-          padding = 4;
-          update_debounce_ms = 150;
+          scroll_debounce_ms = 50;
+          show_background = false;
+          show_other_hints = true;
+          show_parameter_hints = true;
+          show_type_hints = true;
+          toggle_on_modifiers_press = null;
         };
-        # primary_only = false;
-        # update_with_cursor = false;
-        # use_rendered = false;
-      };
-      diagnostics_max_severity = null;
-      # diff_view_style = "split";
-      disable_ai = false;
-      # document_folding_ranges = "off";
-      # document_symbols = "off";
-      double_click_in_multibuffer = "select";
-      drag_and_drop_selection = {
-        delay = 300;
-        enabled = true;
-      };
-      drop_target_size = 0.2;
-      edit_predictions = {
-        disabled_globs = [
+        inline_code_actions = true;
+        # instrumentation = {
+        #   performance_profiler = {
+        #     enabled = false;
+        #   };
+        # };
+        journal = {
+          hour_format = "hour12";
+          path = "~";
+        };
+        jsx_tag_auto_close = {
+          enabled = true;
+        };
+        language_models = {
+          anthropic = {
+            api_url = "https://api.anthropic.com";
+          };
+          google = {
+            api_url = "https://generativelanguage.googleapis.com";
+          };
+          ollama = {
+            api_url = "http://localhost:11434";
+          };
+          openai = {
+            api_url = "https://api.openai.com/v1";
+          };
+        };
+        languages = {
+          CSS = {
+            formatter = {
+              language_server = {
+                name = "biome";
+              };
+            };
+          };
+          Go = {
+            hard_tabs = true;
+            tab_size = 4;
+          };
+          GraphQL = {
+            formatter = {
+              language_server = {
+                name = "biome";
+              };
+            };
+          };
+          Java = {
+            language_servers = [ "jdtls" ];
+          };
+          JavaScript = {
+            code_actions_on_format = {
+              "source.fixAll.biome" = true;
+              "source.organizeImports.biome" = true;
+            };
+            enable_language_server = true;
+            formatter = {
+              language_server = {
+                name = "biome";
+              };
+            };
+            hard_tabs = false;
+            language_servers = [
+              "!eslint"
+              "biome"
+            ];
+            tab_size = 2;
+          };
+          JSON = {
+            code_actions_on_format = {
+              "source.fixAll.biome" = true;
+            };
+            formatter = {
+              language_server = {
+                name = "biome";
+              };
+            };
+            hard_tabs = false;
+            tab_size = 2;
+          };
+          JSONC = {
+            formatter = {
+              language_server = {
+                name = "biome";
+              };
+            };
+          };
+          Kotlin = {
+            language_servers = [
+              "kotlin-lsp"
+              "!kotlin-language-server"
+            ];
+          };
+          Nix = {
+            hard_tabs = true;
+            language_servers = [
+              "nixd"
+              "!nil"
+            ];
+            tab_size = 4;
+          };
+          TSX = {
+            code_actions_on_format = {
+              "source.fixAll.biome" = true;
+              "source.organizeImports.biome" = true;
+            };
+            formatter = {
+              language_server = {
+                name = "biome";
+              };
+            };
+          };
+          TypeScript = {
+            code_actions_on_format = {
+              "source.fixAll.biome" = true;
+              "source.organizeImports.biome" = true;
+            };
+            enable_language_server = true;
+            formatter = {
+              language_server = {
+                name = "biome";
+              };
+            };
+            hard_tabs = false;
+            language_servers = [
+              "!eslint"
+              "!graphql"
+              "!deno"
+              "!typescript-language-server"
+              "biome"
+              "..."
+            ];
+            tab_size = 2;
+          };
+        };
+        # line_ending = "detect";
+        line_indicator_format = "short";
+        linked_edits = true;
+        load_direnv = "shell_hook";
+        lsp = {
+          biome = {
+            settings = {
+              require_config_file = true;
+            };
+          };
+          deno = {
+            settings = {
+              deno = {
+                enable = true;
+              };
+            };
+          };
+          jdtls = {
+            binary = {
+              ignore_system_version = true;
+              path = lib.getExe pkgs.jdt-language-server;
+            };
+          };
+          # kotlin-lsp = {
+          #   binary = {
+          #     path = lib.getExe pkgs.${namespace}.kotlin-lsp;
+          #     arguments = [ "--stdio" ];
+          #   };
+          # };
+          nix = {
+            binary = {
+              path = lib.getExe pkgs.nixd;
+            };
+          };
+          protobuf-language-server = {
+            binary = {
+              path = lib.getExe pkgs.protols;
+            };
+          };
+        };
+        lsp_document_colors = "border";
+        lsp_highlight_debounce = 75;
+        max_tabs = null;
+        middle_click_paste = true;
+        minimap = {
+          current_line_highlight = "line";
+          show = "always";
+          thumb = "always";
+          thumb_border = "left_open";
+        };
+        # mouse_wheel_zoom = false;
+        multi_cursor_modifier = "alt";
+        node = {
+          ignore_system_version = true;
+          npm_path = lib.getExe' pkgs.nodejs_22 "npm";
+          path = lib.getExe pkgs.nodejs_22;
+        };
+        notification_panel = {
+          button = true;
+          dock = "bottom";
+        };
+        on_last_window_closed = "platform_default";
+        outline_panel = {
+          auto_fold_dirs = true;
+          auto_reveal_entries = true;
+          button = true;
+          default_width = 300;
+          dock = "right";
+          file_icons = true;
+          folder_icons = true;
+          git_status = true;
+          indent_guides = {
+            show = "always";
+          };
+          indent_size = 20;
+          scrollbar = {
+            show = null;
+          };
+        };
+        pane_split_direction_horizontal = "up";
+        pane_split_direction_vertical = "left";
+        preferred_line_length = 80;
+        preview_tabs = {
+          enable_keep_preview_on_code_navigation = false;
+          enable_preview_file_from_code_navigation = true;
+          enable_preview_from_file_finder = true;
+          enable_preview_from_multibuffer = true;
+          enable_preview_from_project_panel = true;
+          enable_preview_multibuffer_from_code_navigation = false;
+          enabled = true;
+        };
+        private_files = [
           "**/.env*"
           "**/*.pem"
           "**/*.key"
           "**/*.cert"
           "**/*.crt"
-          "**/.dev.vars"
           "**/secrets.yml"
         ];
-      };
-      edit_predictions_disabled_in = [ ];
-      enable_language_server = true;
-      ensure_final_newline_on_save = true;
-      excerpt_context_lines = 2;
-      expand_excerpt_lines = 5;
-      extend_comment_on_newline = true;
-      # extend_list_on_newline = true;
-      fast_scroll_sensitivity = 4;
-      features = {
-        edit_predictions = {
-          provider = "none";
+        profiles = { };
+        project_panel = {
+          auto_fold_dirs = true;
+          auto_open = {
+            on_create = true;
+            on_drop = true;
+            on_paste = true;
+          };
+          auto_reveal_entries = true;
+          button = true;
+          default_width = 240;
+          dock = "left";
+          drag_and_drop = true;
+          entry_spacing = "comfortable";
+          file_icons = true;
+          folder_icons = true;
+          git_status = true;
+          hide_hidden = false;
+          hide_root = false;
+          indent_guides = {
+            show = "always";
+          };
+          indent_size = 20;
+          scrollbar = {
+            show = null;
+          };
+          show_diagnostics = "all";
+          sort_mode = "directories_first";
+          starts_open = true;
+          sticky_scroll = true;
         };
-      };
-      file_finder = {
-        file_icons = true;
-        modal_max_width = "small";
-        skip_focus_for_active_in_search = true;
-      };
-      file_scan_exclusions = [
-        "**/.git"
-        "**/.svn"
-        "**/.hg"
-        "**/.jj"
-        "**/.sl"
-        "**/.repo"
-        "**/CVS"
-        "**/.DS_Store"
-        "**/Thumbs.db"
-        "**/.classpath"
-        "**/.settings"
-      ];
-      file_scan_inclusions = [ ".env*" ];
-      file_types = {
-        "C" = [
-          "*.c"
-          "*.h"
-        ];
-        "C#" = [ "*.cs" ];
-        "C++" = [
-          "*.cpp"
-          "*.cc"
-          "*.cxx"
-          "*.hpp"
-          "*.hh"
-          "*.hxx"
-        ];
-        "CSS" = [ "*.css" ];
-        "Dart" = [ "*.dart" ];
-        "Dockerfile" = [
-          "Dockerfile*"
-          "*.dockerfile"
-        ];
-        "Go" = [ "*.go" ];
-        "GraphQL" = [
-          "*.graphql"
-          "*.gql"
-        ];
-        "HCL" = [ "*.hcl" ];
-        "HTML" = [
-          "*.html"
-          "*.htm"
-          "*.shtml"
-          "*.xhtml"
-        ];
-        "Java" = [
-          "*.java"
-          "*.jav"
-        ];
-        "JavaScript" = [
-          "*.js"
-          "*.cjs"
-          "*.mjs"
-          "*.jsx"
-        ];
-        "JSONC" = [
-          "**/.zed/**/*.json"
-          "**/zed/**/*.json"
-          "**/Zed/**/*.json"
-          "**/.vscode/**/*.json"
-          "tsconfig.json"
-          "jsconfig.json"
-        ];
-        "Kotlin" = [
-          "*.kt"
-          "*.kts"
-        ];
-        "Lua" = [ "*.lua" ];
-        "Markdown" = [
-          "*.md"
-          "*.markdown"
-        ];
-        "Nix" = [ "*.nix" ];
-        "PHP" = [ "*.php" ];
-        "Proto" = [ "*.proto" ];
-        "Python" = [
-          "*.py"
-          "*.pyi"
-          "SConstruct"
-          "SConscript"
-        ];
-        "Ruby" = [
-          "*.rb"
-          "Rakefile"
-          "Gemfile"
-        ];
-        "Rust" = [ "*.rs" ];
-        "SCSS" = [ "*.scss" ];
-        "Shell Script" = [
-          ".env.*"
-          "*.zsh"
-          "*.bash"
-          "*.sh"
-          "APKBUILD"
-          "PKGBUILD"
-          "*.ebuild"
-          "*.eclass"
-          ".bashrc"
-          ".bash_profile"
-          ".zshrc"
-          ".zprofile"
-        ];
-        "SQL" = [
-          "*.sql"
-          "*.ddl"
-          "*.dml"
-        ];
-        "Swift" = [ "*.swift" ];
-        "Terraform" = [
-          "*.tf"
-          "*.tfvars"
-        ];
-        "TOML" = [ "*.toml" ];
-        "TypeScript" = [
-          "*.ts"
-          "*.cts"
-          "*.mts"
-          "*.tsx"
-        ];
-        "XML" = [
-          "*.xml"
-          "*.xsd"
-          "*.xsl"
-          "*.xslt"
-        ];
-        "YAML" = [
-          "*.yml"
-          "*.yaml"
-        ];
-        "Zig" = [ "*.zig" ];
-      };
-      format_on_save = "on";
-      formatter = "auto";
-      git = {
-        branch_picker = {
-          show_author_name = true;
+        # projects_online_by_default = true;
+        proxy = null;
+        read_ssh_config = true;
+        redact_private_values = false;
+        relative_line_numbers = "disabled";
+        remove_trailing_whitespace_on_save = true;
+        repl = {
+          max_columns = 128;
+          max_lines = 32;
         };
-        git_gutter = "tracked_files";
-        gutter_debounce = null;
-        hunk_style = "staged_hollow";
-        inline_blame = {
-          delay_ms = 600;
+        resize_all_panels_in_dock = [ "left" ];
+        restore_on_file_reopen = true;
+        restore_on_startup = "last_session";
+        rounded_selection = true;
+        scroll_beyond_last_line = "one_page";
+        scroll_sensitivity = 1;
+        scrollbar = {
+          axes = {
+            horizontal = true;
+            vertical = true;
+          };
+          cursors = true;
+          diagnostics = "all";
+          git_diff = true;
+          search_results = true;
+          selected_symbol = true;
+          selected_text = true;
+          show = "auto";
+        };
+        search = {
+          button = true;
+          case_sensitive = false;
+          center_on_match = false;
+          include_ignored = false;
+          regex = false;
+          whole_word = false;
+        };
+        search_wrap = true;
+        seed_search_query_from_cursor = "always";
+        selection_highlight = true;
+        # semantic_tokens = "off";
+        session = {
+          restore_unsaved_buffers = true;
+          trust_all_worktrees = false;
+        };
+        show_call_status_icon = true;
+        show_completion_documentation = true;
+        show_completions_on_input = true;
+        show_edit_predictions = true;
+        show_signature_help_after_edits = false;
+        show_whitespaces = "boundary";
+        show_wrap_guides = true;
+        snippet_sort_order = "inline";
+        soft_wrap = "none";
+        status_bar = {
+          # active_encoding_button = "non_utf8";
+          active_language_button = true;
+          cursor_position_button = true;
+          line_endings_button = false;
+        };
+        tab_bar = {
+          show = true;
+          show_nav_history_buttons = true;
+          show_tab_bar_buttons = true;
+        };
+        tab_size = 2;
+        tabs = {
+          activate_on_close = "history";
+          close_position = "right";
+          file_icons = false;
+          git_status = false;
+          show_close_button = "hover";
+          show_diagnostics = "off";
+        };
+        tasks = {
           enabled = true;
-          # min_column = 0;
-          # padding = 0;
-          # show_commit_summary = false;
+          prefer_lsp = false;
+          variables = { };
         };
-        # worktree_directory = "../worktrees";
-      };
-      git_hosting_providers = [ ];
-      git_panel = {
-        button = true;
-        collapse_untracked_diff = false;
-        default_width = 360;
-        dock = "left";
-        fallback_branch_name = "main";
-        scrollbar = {
-          show = null;
+        telemetry = {
+          diagnostics = true;
+          metrics = true;
         };
-        sort_by_path = false;
-        status_style = "icon";
-      };
-      global_lsp_settings = {
-        button = true;
-        # notifications = {
-        #   dismiss_timeout_ms = 5000;
-        # };
-        # request_timeout = 120;
-      };
-      go_to_definition_fallback = "find_all_references";
-      # go_to_definition_scroll_strategy = "center";
-      gutter = {
-        breakpoints = true;
-        folds = true;
-        line_numbers = true;
-        min_line_number_digits = 4;
-        runnables = true;
-      };
-      hard_tabs = false;
-      helix_mode = false;
-      hide_mouse = "on_typing_and_movement";
-      horizontal_scroll_margin = 5;
-      hover_popover_delay = 300;
-      hover_popover_enabled = true;
-      # hover_popover_hiding_delay = 300;
-      # hover_popover_sticky = true;
-      icon_theme = {
-        dark = "Zed (Default)";
-        light = "Zed (Default)";
-        mode = "system";
-      };
-      image_viewer = {
-        unit = "binary";
-      };
-      indent_guides = {
-        active_line_width = 1;
-        background_coloring = "disabled";
-        coloring = "fixed";
-        enabled = true;
-        line_width = 1;
-      };
-      # indent_list_on_tab = true;
-      inlay_hints = {
-        edit_debounce_ms = 700;
-        enabled = false;
-        scroll_debounce_ms = 50;
-        show_background = false;
-        show_other_hints = true;
-        show_parameter_hints = true;
-        show_type_hints = true;
-        toggle_on_modifiers_press = null;
-      };
-      inline_code_actions = true;
-      # instrumentation = {
-      #   performance_profiler = {
-      #     enabled = false;
-      #   };
-      # };
-      journal = {
-        hour_format = "hour12";
-        path = "~";
-      };
-      jsx_tag_auto_close = {
-        enabled = true;
-      };
-      language_models = {
-        anthropic = {
-          api_url = "https://api.anthropic.com";
-        };
-        google = {
-          api_url = "https://generativelanguage.googleapis.com";
-        };
-        ollama = {
-          api_url = "http://localhost:11434";
-        };
-        openai = {
-          api_url = "https://api.openai.com/v1";
-        };
-      };
-      languages = {
-        CSS = {
-          formatter = {
-            language_server = {
-              name = "biome";
+        terminal = {
+          alternate_scroll = "off";
+          blinking = "off";
+          button = false;
+          copy_on_select = false;
+          default_height = 320;
+          default_width = 640;
+          detect_venv = {
+            on = {
+              activate_script = "default";
+              directories = [
+                ".env"
+                "env"
+                ".venv"
+                "venv"
+              ];
             };
           };
-        };
-        Go = {
-          hard_tabs = true;
-          tab_size = 4;
-        };
-        GraphQL = {
-          formatter = {
-            language_server = {
-              name = "biome";
-            };
+          dock = "bottom";
+          env = {
+            TERM = "ghostty";
           };
-        };
-        Java = {
-          language_servers = [ "jdtls" ];
-        };
-        JavaScript = {
-          code_actions_on_format = {
-            "source.fixAll.biome" = true;
-            "source.organizeImports.biome" = true;
-          };
-          enable_language_server = true;
-          formatter = {
-            language_server = {
-              name = "biome";
-            };
-          };
-          hard_tabs = false;
-          language_servers = [
-            "!eslint"
-            "biome"
+          font_family = "IntoneMono Nerd Font Mono";
+          font_features = null;
+          font_size = null;
+          keep_selection_on_copy = true;
+          line_height = "comfortable";
+          minimum_contrast = 45;
+          option_as_meta = false;
+          path_hyperlink_regexes = [
+            "File \"(?<path>[^\"]+)\", line (?<line>[0-9]+)"
+            "(?x)"
+            "# optionally starts with 0-2 opening prefix symbols"
+            "[({\\[<]{0,2}"
+            "# which may be followed by an opening quote"
+            "(?<quote>[\"'`])?"
+            "# `path` is the shortest sequence of any non-space character"
+            "(?<link>(?<path>[^ ]+?"
+            "    # which may end with a line and optionally a column,"
+            "    (?<line_column>:+[0-9]+(:[0-9]+)?|:?\\([0-9]+([,:][0-9]+)?\\))?"
+            "))"
+            "# which must be followed by a matching quote"
+            "(?(<quote>)\\k<quote>)"
+            "# and optionally a single closing symbol"
+            "[)}\\]>]?"
+            "# if line/column matched, may be followed by a description"
+            "(?(<line_column>):[^ 0-9][^ ]*)?"
+            "# which may be followed by trailing punctuation"
+            "[.,:)}\\]>]*"
+            "# and always includes trailing whitespace or end of line"
+            "([ ]+|$)"
           ];
-          tab_size = 2;
-        };
-        JSON = {
-          code_actions_on_format = {
-            "source.fixAll.biome" = true;
+          path_hyperlink_timeout_ms = 1;
+          scroll_multiplier = 3;
+          scrollbar = {
+            show = null;
           };
-          formatter = {
-            language_server = {
-              name = "biome";
-            };
+          shell = "system";
+          toolbar = {
+            breadcrumbs = false;
           };
-          hard_tabs = false;
-          tab_size = 2;
+          working_directory = "current_project_directory";
         };
-        JSONC = {
-          formatter = {
-            language_server = {
-              name = "biome";
-            };
-          };
+        # text_rendering_mode = "platform_default";
+        theme = {
+          dark = "Palenight Theme";
+          light = "Tokyo Night Storm";
+          mode = "system";
         };
-        Kotlin = {
-          language_servers = [
-            "kotlin-lsp"
-            "!kotlin-language-server"
-          ];
-        };
-        Nix = {
-          hard_tabs = true;
-          language_servers = [
-            "nixd"
-            "!nil"
-          ];
-          tab_size = 4;
-        };
-        TSX = {
-          code_actions_on_format = {
-            "source.fixAll.biome" = true;
-            "source.organizeImports.biome" = true;
-          };
-          formatter = {
-            language_server = {
-              name = "biome";
-            };
+        theme_overrides = {
+          "Palenight Theme" = {
+            # Error diagnostics - bright red tones for visibility
+            "error" = "#ff5370";
+            "error.background" = "#ff537020";
+            "error.border" = "#ff5370";
+
+            # Warning diagnostics - amber/orange tones
+            "warning" = "#ffcb6b";
+            "warning.background" = "#ffcb6b20";
+            "warning.border" = "#ffcb6b";
+
+            # Info diagnostics - blue tones
+            "info" = "#82aaff";
+            "info.background" = "#82aaff20";
+            "info.border" = "#82aaff";
+
+            # Hint diagnostics - subtle cyan
+            "hint" = "#89ddff";
+            "hint.background" = "#89ddff15";
+            "hint.border" = "#89ddff";
           };
         };
-        TypeScript = {
-          code_actions_on_format = {
-            "source.fixAll.biome" = true;
-            "source.organizeImports.biome" = true;
-          };
-          enable_language_server = true;
-          formatter = {
-            language_server = {
-              name = "biome";
-            };
-          };
-          hard_tabs = false;
-          language_servers = [
-            "!eslint"
-            "!graphql"
-            "!deno"
-            "!typescript-language-server"
-            "biome"
-            "..."
-          ];
-          tab_size = 2;
+        title_bar = {
+          show_branch_icon = false;
+          show_branch_name = true;
+          show_menus = false;
+          show_onboarding_banner = true;
+          show_project_items = true;
+          show_sign_in = true;
+          show_user_menu = true;
+          show_user_picture = true;
         };
-      };
-      # line_ending = "detect";
-      line_indicator_format = "short";
-      linked_edits = true;
-      load_direnv = "shell_hook";
-      lsp = {
-        biome = {
-          settings = {
-            require_config_file = true;
-          };
-        };
-        deno = {
-          settings = {
-            deno = {
-              enable = true;
-            };
-          };
-        };
-        jdtls = {
-          binary = {
-            ignore_system_version = true;
-            path = lib.getExe pkgs.jdt-language-server;
-          };
-        };
-        # kotlin-lsp = {
-        #   binary = {
-        #     path = lib.getExe pkgs.${namespace}.kotlin-lsp;
-        #     arguments = [ "--stdio" ];
-        #   };
-        # };
-        nix = {
-          binary = {
-            path = lib.getExe pkgs.nixd;
-          };
-        };
-        protobuf-language-server = {
-          binary = {
-            path = lib.getExe pkgs.protols;
-          };
-        };
-      };
-      lsp_document_colors = "border";
-      lsp_highlight_debounce = 75;
-      max_tabs = null;
-      middle_click_paste = true;
-      minimap = {
-        current_line_highlight = "line";
-        show = "always";
-        thumb = "always";
-        thumb_border = "left_open";
-      };
-      # mouse_wheel_zoom = false;
-      multi_cursor_modifier = "alt";
-      node = {
-        ignore_system_version = true;
-        npm_path = lib.getExe' pkgs.nodejs_22 "npm";
-        path = lib.getExe pkgs.nodejs_22;
-      };
-      notification_panel = {
-        button = true;
-        dock = "bottom";
-      };
-      on_last_window_closed = "platform_default";
-      outline_panel = {
-        auto_fold_dirs = true;
-        auto_reveal_entries = true;
-        button = true;
-        default_width = 300;
-        dock = "right";
-        file_icons = true;
-        folder_icons = true;
-        git_status = true;
-        indent_guides = {
-          show = "always";
-        };
-        indent_size = 20;
-        scrollbar = {
-          show = null;
-        };
-      };
-      pane_split_direction_horizontal = "up";
-      pane_split_direction_vertical = "left";
-      preferred_line_length = 80;
-      preview_tabs = {
-        enable_keep_preview_on_code_navigation = false;
-        enable_preview_file_from_code_navigation = true;
-        enable_preview_from_file_finder = true;
-        enable_preview_from_multibuffer = true;
-        enable_preview_from_project_panel = true;
-        enable_preview_multibuffer_from_code_navigation = false;
-        enabled = true;
-      };
-      private_files = [
-        "**/.env*"
-        "**/*.pem"
-        "**/*.key"
-        "**/*.cert"
-        "**/*.crt"
-        "**/secrets.yml"
-      ];
-      profiles = { };
-      project_panel = {
-        auto_fold_dirs = true;
-        auto_open = {
-          on_create = true;
-          on_drop = true;
-          on_paste = true;
-        };
-        auto_reveal_entries = true;
-        button = true;
-        default_width = 240;
-        dock = "left";
-        drag_and_drop = true;
-        entry_spacing = "comfortable";
-        file_icons = true;
-        folder_icons = true;
-        git_status = true;
-        hide_hidden = false;
-        hide_root = false;
-        indent_guides = {
-          show = "always";
-        };
-        indent_size = 20;
-        scrollbar = {
-          show = null;
-        };
-        show_diagnostics = "all";
-        sort_mode = "directories_first";
-        starts_open = true;
-        sticky_scroll = true;
-      };
-      # projects_online_by_default = true;
-      proxy = null;
-      read_ssh_config = true;
-      redact_private_values = false;
-      relative_line_numbers = "disabled";
-      remove_trailing_whitespace_on_save = true;
-      repl = {
-        max_columns = 128;
-        max_lines = 32;
-      };
-      resize_all_panels_in_dock = [ "left" ];
-      restore_on_file_reopen = true;
-      restore_on_startup = "last_session";
-      rounded_selection = true;
-      scroll_beyond_last_line = "one_page";
-      scroll_sensitivity = 1;
-      scrollbar = {
-        axes = {
-          horizontal = true;
-          vertical = true;
-        };
-        cursors = true;
-        diagnostics = "all";
-        git_diff = true;
-        search_results = true;
-        selected_symbol = true;
-        selected_text = true;
-        show = "auto";
-      };
-      search = {
-        button = true;
-        case_sensitive = false;
-        center_on_match = false;
-        include_ignored = false;
-        regex = false;
-        whole_word = false;
-      };
-      search_wrap = true;
-      seed_search_query_from_cursor = "always";
-      selection_highlight = true;
-      # semantic_tokens = "off";
-      session = {
-        restore_unsaved_buffers = true;
-        trust_all_worktrees = false;
-      };
-      show_call_status_icon = true;
-      show_completion_documentation = true;
-      show_completions_on_input = true;
-      show_edit_predictions = true;
-      show_signature_help_after_edits = false;
-      show_whitespaces = "boundary";
-      show_wrap_guides = true;
-      snippet_sort_order = "inline";
-      soft_wrap = "none";
-      status_bar = {
-        # active_encoding_button = "non_utf8";
-        active_language_button = true;
-        cursor_position_button = true;
-        line_endings_button = false;
-      };
-      tab_bar = {
-        show = true;
-        show_nav_history_buttons = true;
-        show_tab_bar_buttons = true;
-      };
-      tab_size = 2;
-      tabs = {
-        activate_on_close = "history";
-        close_position = "right";
-        file_icons = false;
-        git_status = false;
-        show_close_button = "hover";
-        show_diagnostics = "off";
-      };
-      tasks = {
-        enabled = true;
-        prefer_lsp = false;
-        variables = { };
-      };
-      telemetry = {
-        diagnostics = true;
-        metrics = true;
-      };
-      terminal = {
-        alternate_scroll = "off";
-        blinking = "off";
-        button = false;
-        copy_on_select = false;
-        default_height = 320;
-        default_width = 640;
-        detect_venv = {
-          on = {
-            activate_script = "default";
-            directories = [
-              ".env"
-              "env"
-              ".venv"
-              "venv"
-            ];
-          };
-        };
-        dock = "bottom";
-        env = {
-          TERM = "ghostty";
-        };
-        font_family = "IntoneMono Nerd Font Mono";
-        font_features = null;
-        font_size = null;
-        keep_selection_on_copy = true;
-        line_height = "comfortable";
-        minimum_contrast = 45;
-        option_as_meta = false;
-        path_hyperlink_regexes = [
-          "File \"(?<path>[^\"]+)\", line (?<line>[0-9]+)"
-          "(?x)"
-          "# optionally starts with 0-2 opening prefix symbols"
-          "[({\\[<]{0,2}"
-          "# which may be followed by an opening quote"
-          "(?<quote>[\"'`])?"
-          "# `path` is the shortest sequence of any non-space character"
-          "(?<link>(?<path>[^ ]+?"
-          "    # which may end with a line and optionally a column,"
-          "    (?<line_column>:+[0-9]+(:[0-9]+)?|:?\\([0-9]+([,:][0-9]+)?\\))?"
-          "))"
-          "# which must be followed by a matching quote"
-          "(?(<quote>)\\k<quote>)"
-          "# and optionally a single closing symbol"
-          "[)}\\]>]?"
-          "# if line/column matched, may be followed by a description"
-          "(?(<line_column>):[^ 0-9][^ ]*)?"
-          "# which may be followed by trailing punctuation"
-          "[.,:)}\\]>]*"
-          "# and always includes trailing whitespace or end of line"
-          "([ ]+|$)"
-        ];
-        path_hyperlink_timeout_ms = 1;
-        scroll_multiplier = 3;
-        scrollbar = {
-          show = null;
-        };
-        shell = "system";
         toolbar = {
-          breadcrumbs = false;
+          agent_review = true;
+          breadcrumbs = true;
+          code_actions = false;
+          quick_actions = true;
+          selections_menu = true;
         };
-        working_directory = "current_project_directory";
-      };
-      # text_rendering_mode = "platform_default";
-      theme = {
-        dark = "Palenight Theme";
-        light = "Tokyo Night Storm";
-        mode = "system";
-      };
-      theme_overrides = {
-        "Palenight Theme" = {
-          # Error diagnostics - bright red tones for visibility
-          "error" = "#ff5370";
-          "error.background" = "#ff537020";
-          "error.border" = "#ff5370";
-
-          # Warning diagnostics - amber/orange tones
-          "warning" = "#ffcb6b";
-          "warning.background" = "#ffcb6b20";
-          "warning.border" = "#ffcb6b";
-
-          # Info diagnostics - blue tones
-          "info" = "#82aaff";
-          "info.background" = "#82aaff20";
-          "info.border" = "#82aaff";
-
-          # Hint diagnostics - subtle cyan
-          "hint" = "#89ddff";
-          "hint.background" = "#89ddff15";
-          "hint.border" = "#89ddff";
+        ui_font_fallbacks = null;
+        ui_font_family = "IntoneMono Nerd Font Mono";
+        ui_font_features = {
+          calt = false;
         };
+        ui_font_size = 12;
+        ui_font_weight = 400;
+        unnecessary_code_fade = 0.3;
+        use_auto_surround = true;
+        use_autoclose = true;
+        use_on_type_format = true;
+        use_smartcase_search = false;
+        use_system_path_prompts = true;
+        use_system_prompts = true;
+        use_system_window_tabs = false;
+        vertical_scroll_margin = 3;
+        vim_mode = false;
+        when_closing_with_no_tabs = "platform_default";
+        whitespace_map = {
+          space = "•";
+          tab = "→";
+        };
+        wrap_guides = [ ];
       };
-      title_bar = {
-        show_branch_icon = false;
-        show_branch_name = true;
-        show_menus = false;
-        show_onboarding_banner = true;
-        show_project_items = true;
-        show_sign_in = true;
-        show_user_menu = true;
-        show_user_picture = true;
-      };
-      toolbar = {
-        agent_review = true;
-        breadcrumbs = true;
-        code_actions = false;
-        quick_actions = true;
-        selections_menu = true;
-      };
-      ui_font_fallbacks = null;
-      ui_font_family = "IntoneMono Nerd Font Mono";
-      ui_font_features = {
-        calt = false;
-      };
-      ui_font_size = 12;
-      ui_font_weight = 400;
-      unnecessary_code_fade = 0.3;
-      use_auto_surround = true;
-      use_autoclose = true;
-      use_on_type_format = true;
-      use_smartcase_search = false;
-      use_system_path_prompts = true;
-      use_system_prompts = true;
-      use_system_window_tabs = false;
-      vertical_scroll_margin = 3;
-      vim_mode = false;
-      when_closing_with_no_tabs = "platform_default";
-      whitespace_map = {
-        space = "•";
-        tab = "→";
-      };
-      wrap_guides = [ ];
     };
   };
 }

--- a/modules/nixos/nvidia/default.nix
+++ b/modules/nixos/nvidia/default.nix
@@ -17,6 +17,19 @@ in
     services.xserver.enable = true;
     services.xserver.videoDrivers = [ "nvidia" ];
 
+    boot = {
+      kernelModules = [
+        "nvidia"
+        "nvidia_modeset"
+        "nvidia_uvm"
+        "nvidia_drm"
+      ];
+      kernelParams = [
+        "nvidia-drm.modeset=1"
+        "nvidia-drm.fbdev=1"
+      ];
+    };
+
     hardware = {
       graphics = {
         enable = true;

--- a/modules/nixos/wireguard/default.nix
+++ b/modules/nixos/wireguard/default.nix
@@ -79,6 +79,12 @@
         dns = config.${namespace}.wireguard.dns;
         privateKeyFile = config.${namespace}.wireguard.privateKeyFile;
 
+        # Never start the tunnel at boot: with allowedIPs 0.0.0.0/0, wg-quick up
+        # succeeds even when the endpoint is unreachable and blackholes all
+        # traffic (and DNS). The tunnel comes up on demand via the waybar VPN
+        # button only.
+        autostart = false;
+
         peers = map (
           peer:
           {

--- a/packages/uni-sync/default.nix
+++ b/packages/uni-sync/default.nix
@@ -1,0 +1,42 @@
+# uni-sync — boot-time fan configuration for Lian Li Uni fan hubs.
+#
+# Pinned to tymscar's fork (upstream PR: https://github.com/EightB1ts/uni-sync/pull/32)
+# because the UNI FAN SL v1.2 hub (0cf2:a100) ignores HID writes entirely — its firmware
+# only speaks a vendor control-transfer protocol (setup channel -> RPM LE16 -> commit),
+# which neither upstream uni-sync nor liquidctl implement yet
+# (https://github.com/liquidctl/liquidctl/issues/858). Drop this fork and use
+# upstream/nixpkgs once PR #32 (or liquidctl support) lands.
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  pkg-config,
+  libusb1,
+  udev,
+}:
+rustPlatform.buildRustPackage {
+  pname = "uni-sync";
+  version = "0.3.1-pr32-sl-v1.2";
+
+  src = fetchFromGitHub {
+    owner = "tymscar";
+    repo = "uni-sync";
+    rev = "ea0a35840dbdace39e8881aa850e304b4abc8dcb";
+    hash = "sha256-psA/e1u6i2snB/eaYSmC3hsKjFYUgs+EarGX3bhhw1M=";
+  };
+
+  cargoHash = "sha256-pprX8/d3x5u4ZegkAwBZ7fhf1IDFEcKHH/RuS5pXyBE=";
+
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [
+    libusb1
+    udev
+  ];
+
+  meta = {
+    description = "Lian Li Uni fan hub speed tool (fork with SL v1.2 vendor-transfer support)";
+    mainProgram = "uni-sync";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.linux;
+  };
+}

--- a/secrets/arrayofone.yaml
+++ b/secrets/arrayofone.yaml
@@ -1,28 +1,30 @@
 git:
-    name: ENC[AES256_GCM,data:wA7md/GDvWt6AQ==,iv:b+uzgZgJ1ZZNoUZjpQSl27BboFdsp9St+WtPuIyoU3E=,tag:TxFclEAaGMkstPJ1VImzMg==,type:str]
-    email: ENC[AES256_GCM,data:gP8chWGWIpNjecjIN8S4iY3v+YARNQ6/6RJIjiUaFzHZ4+q9AjUjbmUFb3w=,iv:0a69q7dwpWcH03VzBN2bizlDwQsxQh2mGYF/QUP/LGs=,tag:IKQBxNANKxEki4W+g7XTbQ==,type:str]
+    name: ENC[AES256_GCM,data:1Ck9jKVIsbBBZQ==,iv:OwvfN4NmYMruqLDPUFvli31xQUV8dVF1o3ZiMxhkDhw=,tag:CJ9EHp8gtrBbkMTIrsnLvQ==,type:str]
+    email: ENC[AES256_GCM,data:RRIzSmF3LRcid/DWKdmkadITK51iPbQ3r5X1NnbMFCq/MRAnwmttRpthLhI=,iv:YFqmwaUGlCwFSRcNvWBc+lkdBAdAVvjzCilbyCXF4hw=,tag:lRHjKF7jFK3/MAWemTT8Xw==,type:str]
     gh:
-        ssh-private: ENC[AES256_GCM,data:JD3afmODAGotbbzIQn77sGM7YP5tIm7z4auRXM2hNWoHc5F8oZMFfYD6piN1+jGWXNbjY6tKJs1UMXeqnYNMuMYsnZmSrjB8sz+/sE24/wJpIWyKmE+Y2XFJUM5HWptBcB9hOaH5xJIVMiFIycez5DendVnkJBzwTErO+Kb4O5YjYHDCLMXBrh81MLFDltEhGg9QanlGxU2t50RZXn0GjOLM1bVOaDQVtOE1wOFdHgGB6Re1E/b1vnIzyj9NK0rVThf+BALZS7WNfl4AxZnQW8ptulXyDe/gSj5nNMnTWGtxWJW6POVnI1XikX+wG+yVCC3IQ5ef1nA7slyEsDt4dXab4cfyHRjvx59b9okJc1ptMbjTQLnWVfBQP1NmswTpr4lozgDZHJQOx3fBtt5kTzMe+PzC9FpDMcTKCbAwWjyNtQtqm+ZYe79JyFRi7cUzq55jzWXaZouMLk/g1msx+C02hk5bLe54z7Th/YLehgKt3gFlZJC7KYbaPQy/EAjiopZUq88ydsX2Za4QAzwgj2ElkK6pK9NW8cyJ,iv:WpvvGFbQPJV98OXDacRU6D4WpSQAB51AWaZMiFSX6VE=,tag:peoZC8bLHYOQz6jwqw3uOw==,type:str]
-        ssh-public: ENC[AES256_GCM,data:C6rhlzUdlfHir1Qw4Fr8AlPwV9E5J3xLyEqxSlZD7RBf4ceZ85VPk4DDcLVZ2TlO5kYBr1sx9bKsBNK5bamwQ9WckwvPcTTztZMo6V2vpFOE3MiyL/OfQze14ttPmYnrKw==,iv:lgJqn6A18NZl2whbeP6MVPrt+bRkdOpY0rKIO1k+PEI=,tag:JI7Z2Ju2npDzMvOUPn0T5Q==,type:str]
+        ssh-private: ENC[AES256_GCM,data:4eW+LWe8lxS1o2tW5RH2FPG/fRXYW+QgJDjyskoNbXX6RTQXEvPyZm61/CKpHM8TS05/48hesXIOI/BtP78DhbU1CCwHn3MIgEOE3A6JTrAk/ZOiAVqVCUq96bigGqz1X4Xk4GTlVf0eY8uKj5oBe6++8oI76ca9AxzHYXuOGMcwF8pGl/jzFHsG1MZ3TFuuhZkDz6OowEbKWOqi56y00lKVLGKOw7BXwu4whR8hC1fMOg9WC5jzqnwHbrZeXee/qWxGXJmG81obU8ehyr3luNGrr7CMEF4MpiOkN38R/U/pA1k3IMlzgwoYiplmxQNxJwhSjvbW75+g/PCCiVY3wl1eBYeWbqF+QyV+Mq/Z36Y4ZhgUvn5XVK4zzkUdU7C3acH7sV/xkt/rfhpluU/8RMlsXJnaaLdyw9j9m48OhYjTGyq4qqJAqbPY4egOEz5NJf3Jr9ybVZMAaqDH8D2CWM55Lr/tQtwKBTW7/Sgku3N36VF4nabwMGLZusCZ3zfkKjr/s+LMPP5cB2ejn6iU55nRdnADSRHZN+g6,iv:xQLfrD36pijcQv6pCFhIqULun/TqCKSm7WbZmdEXYVs=,tag:3swbY+0odpeDxufa6zjy8w==,type:str]
+        ssh-public: ENC[AES256_GCM,data:c5wp3UEBxTosxLPfdHNo8AksZsnnX6Fx0SkmSYBLouBQfZICrjzYaaU/PYime8YSXzPBfVM7utOAntlqmzaEc/8aLmeuMp4LsEFG7jaAYjFmNbQKzyBz/FVo4aTWxrSz9w==,iv:bLaocA/xlM1dyuxBqD4rH5Gw3MVr4SyezW1NYYmPdaE=,tag:EKDdauFvnlUoXSOImpB5KA==,type:str]
 ai:
     anthropic:
-        api-key: ENC[AES256_GCM,data:6d2U9FkuzHM3gCOiuMjxmmwS5FtzcyZXxod0IwIN/UqpMTfVAl11q/MxGOsKOV0G3tjl1rH5bYSqnPlezD/LTZi20rQufytHzTRPns98kWz6gdzwxDz//LEY8GHAo11nNOEjLu0eNnbaH0Ho,iv:P4iN6rvmjZam2trmtAQxjtDru/IrxEagk6QCbCFH6tQ=,tag:GPSZYsPvyJQV1H6bJy3snQ==,type:str]
+        api-key: ENC[AES256_GCM,data:GJ/8w8GvTJhMPYtKMN9mFjW4QuucITpPDAfqajSsclyXAO1aYENyAy0aZ5j4lDjepYUWCmaXJOhubhlGt+EGrI93sZYrIbxvpx2t14Uhm2xuo8BRKXhb4GoMvnpEmaSenUrbRQak1Qs7isO4,iv:fll1mJig0Votisqm2DA8jfDTSd2icbSLjy4sJNaEUhQ=,tag:4VXMZ1A0XDKBHITGmsaQEA==,type:str]
     gemini:
-        api-key: ENC[AES256_GCM,data:FHTdZqxkEVF0KkpmI4kZJOQMSpt4yqazlySYPL63wAyUBljgby73,iv:Xa5SmMRR2nYFuNrDSvTRh81hWi4JatlwdwvYKuaEUtc=,tag:dLmsr61jv8lOFiCv2FcthQ==,type:str]
+        api-key: ENC[AES256_GCM,data:HM6yZwuBSZ5g5aACScxLDkTtE2tggFrjZ8t+7P8M4tzFRQgUHzh/,iv:FXNdws1b/cXkWH7NfUaPehNHAxfXz9zEAxFiAU+cE9M=,tag:KVfhJEHTO2jYYmxkxnkWrA==,type:str]
+localstack:
+    auth-token: ""
 digits:
-    email: ENC[AES256_GCM,data:c5JrJZxk62tnpyamSjWDrmY=,iv:yrDrM5VmKaoZ8lhTy+wIQaAr6aLKY8D6/zfDmQ/nAVU=,tag:pV4+OG0egY5NUU9sAOtDnQ==,type:str]
+    email: ENC[AES256_GCM,data:9ukifnpg8t/hzvWeg8yP9Ag=,iv:Y/zZ5JqPt8F7MOHgFBWXOVx1hKyg/cSkcnJ1X6Y784I=,tag:5JixXj0+668TwqOkJjKnEQ==,type:str]
 sops:
     age:
         - recipient: age19r87m08mt03zg8ustzlx733s4m4wph6vvkd0qxlequfje5k0mawsy68vp2
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB3QkVYaWRuMFhRSlcwV3Fq
-            U3hWaUdldkJBblV1U3hRdVBJTjJwcVpxd0JVCk1HVVBNSGZzblFwSXJzek5TUEFJ
-            MWF2ckQwc2NtUGRqeDk3R3Q4cHlpTlkKLS0tIGk5ZDRyb3hhWS9BRFQ0d3NMMEJx
-            dXNCRGsvM1pZd3pWeGNmVzJnVkJMelEKFrd6yacZO9Y9+Z3M5PPd1IKsedlEXsD7
-            +kpZ/Sv7jWqg0CI9EUEtI3lwmTTrOzc4zYON7c2wW2WXwdo/fOFClQ==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA0KzcrR0FURmRKWlhaOWQw
+            T3BMZmlyemt3bjhNRTB3bWl5TUxMdGxOMkJRCmhPMVQzVnpMaFlUYU40aUUzNEcz
+            STFmbndtdTJQZ1g2OGxxNlU0M0lhSTAKLS0tIDdnSDlJMWpSdnFEZVpoVjdUMjNj
+            aWZsSUQ5WHdwNmVuMk1NZGNyWGVCS1EKNIxHl+sFGpDTPRh1LiWpSHyX/yRWzVzH
+            QkW0kKWwrjdmDMVPGEFp0IecElZzUPcxINP9cAsxR0Z6NbVFjiibpA==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2025-11-14T23:32:48Z"
-    mac: ENC[AES256_GCM,data:x7JYSY/E72IusCneXgouQk/SpLgeIX2tPdFq6Tm4uFNDYe+x09rbWFajPZUog9uRK06d8G2cXHbH7Fu/v9WoaxTICieMpv3PR8tVqzfYXCsLbWLEKL4heUF/nNmjWLxskaB45tWouDLyWP5vZF81GYAIqu9RG2lHUKG2uK9qLNI=,iv:+h4K6TyWcsThMVFowljSJxwKAVk9arR/v2hRJAwxO5M=,tag:ksBP0Qe/22I1tAaT3f5X5A==,type:str]
+    lastmodified: "2026-05-29T21:57:58Z"
+    mac: ENC[AES256_GCM,data:2aUqp4FvB9wOqmHen3KNRkACeSSKjTzCARqsqPfTWV4wKhjKhDZymgCanUvVWIgpDrOIx4vcz2FbhQZ0EalNdWP9dq3LVy7c4MUS5ppUuqNJTM5OwyakIF/yIw/CsROA539sP/DhQaWoFsc63+1DPimtl1E7+lEA7rD+RKSnU3o=,iv:fxWse+fItza7NYkcSsEkt5YVC1MDHnjUWRtKG6QX14k=,tag:Qmk4Tq06MbFYHyrHuj9jTA==,type:str]
     unencrypted_suffix: _unencrypted
-    version: 3.11.0
+    version: 3.12.2

--- a/systems/aarch64-darwin/mingabook/default.nix
+++ b/systems/aarch64-darwin/mingabook/default.nix
@@ -55,7 +55,8 @@
   environment.systemPackages = with pkgs; [
     awscli2
     mkcert
-    nodejs_20
+    # nodejs_20 was removed from nixpkgs after its 2026-04-30 EOL
+    nodejs_22
     pnpm
     python3
     raycast

--- a/systems/aarch64-linux/agent/default.nix
+++ b/systems/aarch64-linux/agent/default.nix
@@ -1,8 +1,20 @@
 { pkgs, ... }:
 {
-  boot.kernelPackages =
-    (import (builtins.fetchTarball "https://gitlab.com/vriska/nix-rpi5/-/archive/main.tar.gz"))
-    .legacyPackages.aarch64-linux.linuxPackages_rpi5;
+  # Mainline kernel for now. The previous unpinned fetchTarball of a
+  # third-party nix-rpi5 repo broke pure evaluation; the vendor Pi 5
+  # kernel/firmware returns via nixos-raspberrypi in the pi-netboot plan's
+  # Phase 5 (see flake.nix note on the current upstream incompatibility).
+
+  # SD boot via the firmware's extlinux path, as on the stock aarch64 sd-image
+  boot.loader.grub.enable = false;
+  boot.loader.generic-extlinux-compatible.enable = true;
+
+  # Standard Pi sd-image layout; superseded by the fellowship.worker root
+  # modes when the netboot plan's Phase 5 lands.
+  fileSystems."/" = {
+    device = "/dev/disk/by-label/NIXOS_SD";
+    fsType = "ext4";
+  };
 
   networking = { };
 

--- a/systems/x86_64-linux/baradur/default.nix
+++ b/systems/x86_64-linux/baradur/default.nix
@@ -19,6 +19,7 @@
     gc = {
       automatic = true;
       dates = [ "05:00" ];
+      options = "--delete-older-than 14d";
     };
   };
 
@@ -27,7 +28,16 @@
   networking.hostName = "baradur";
 
   boot = {
-    kernelPackages = pkgs.linuxPackages_6_6;
+    kernelPackages = pkgs.linuxPackages_latest;
+
+    # MSI board Super I/O (NCT6687) — exposes motherboard fan headers + temps to lm_sensors/coolercontrol
+    extraModulePackages = [ config.boot.kernelPackages.nct6687d ];
+    kernelModules = [ "nct6687" ];
+
+    # teo ignores iowait counts; menu keeps cores in shallow C-states whenever iowait is pending,
+    # and ghostty's io_uring event loops pin phantom iowait 24/7. Only takes effect once
+    # Global C-state Control is re-enabled in BIOS (cpuidle driver is "none" without it).
+    kernelParams = [ "cpuidle.governor=teo" ];
 
     loader = {
       systemd-boot.enable = false;
@@ -42,6 +52,7 @@
         device = "nodev";
         useOSProber = true;
         efiSupport = true;
+        configurationLimit = 10;
       };
     };
   };
@@ -110,20 +121,20 @@
 
   environment = {
     systemPackages = with pkgs; [
-      dconf
       ghostty
-      libqalculate
       mdadm
       pciutils
       proton-pass
       qalculate-gtk
       shotman
       usbutils
+      lm_sensors
       libsecret
       gimp
       cherry-studio
       nvitop
       zoom-us
+      python3 # on PATH for Claude Code stop hooks that shell out to python3
     ];
 
     sessionVariables = {
@@ -132,6 +143,11 @@
   };
 
   services = {
+    # Holds the Corsair Commander ST (AIO) in software lighting mode and drives the LEDs,
+    # which stops CoolerControl's once-per-poll hardware-lighting blink (liquidctl#448:
+    # unfixable in liquidctl; software-mode lighting is immune while OpenRGB runs).
+    hardware.openrgb.enable = true;
+
     openssh.enable = true;
     printing.enable = true;
     pipewire = {
@@ -139,22 +155,10 @@
       alsa.enable = true;
       alsa.support32Bit = true;
       pulse.enable = true;
-
-      extraConfig.pipewire-pulse = {
-        "99-disable-suspend" = {
-          "pulse.cmd" = [
-            {
-              cmd = "unload-module";
-              args = "module-suspend-on-idle";
-              flags = [ "nofail" ];
-            }
-          ];
-        };
-      };
     };
 
     ollama = {
-      enable = true;
+      enable = false;
       package = pkgs.ollama-cuda;
       loadModels = [
         "deepseek-r1:14b"
@@ -165,7 +169,7 @@
     };
 
     open-webui = {
-      enable = true;
+      enable = false;
       host = "0.0.0.0";
       port = 1111;
       environment = {
@@ -196,6 +200,10 @@
           command = "/run/current-system/sw/bin/systemctl stop wg-quick-wg0.service";
           options = [ "NOPASSWD" ];
         }
+        {
+          command = "/run/current-system/sw/bin/wg show wg0 latest-handshakes";
+          options = [ "NOPASSWD" ];
+        }
       ];
     }
   ];
@@ -205,6 +213,9 @@
     dconf.enable = true;
     thunar.enable = true;
 
+    # Fan curve control for the Lian Li UNI hub + Corsair Commander Core (L-Connect/iCUE equivalent)
+    coolercontrol.enable = true;
+
     steam = {
       enable = true;
       remotePlay.openFirewall = true;
@@ -213,14 +224,38 @@
     };
   };
 
+  # Lian Li UNI FAN SL v1.2 hub: firmware ignores HID writes, so CoolerControl/liquidctl
+  # can't drive it (liquidctl#858). This fork speaks the vendor control-transfer protocol
+  # and applies /etc/uni-sync/uni-sync.json at boot. First run generates the file with
+  # detected devices; set each channel to mode "Manual" + speed (percent), then restart.
+  systemd.services.uni-sync = {
+    description = "Apply Lian Li Uni fan hub speeds";
+    wantedBy = [ "multi-user.target" ];
+    serviceConfig = {
+      Type = "oneshot";
+      ExecStart = "${pkgs.${namespace}.uni-sync}/bin/uni-sync";
+    };
+  };
+
+  hardware = {
+    nvidia-container-toolkit.enable = true;
+
+    enableAllFirmware = true;
+    enableRedistributableFirmware = true;
+
+    bluetooth = {
+      enable = true;
+      powerOnBoot = true;
+    };
+  };
+
+  services.blueman.enable = true;
+
   virtualisation = {
     oci-containers.backend = "podman";
 
     containers.enable = true;
-    docker = {
-    	enable = true;
-	enableNvidia = true;
-	};
+    docker.enable = true;
   };
 
   nixpkgs.config.allowUnfree = true;


### PR DESCRIPTION
## Why

Booting into Hyprland via SDDM showed the **autogenerated-config warning with no keybindings**. Root cause: the `hyprland` flake input tracks master, and the lock bump pulled a post-v0.56.0 build in which **hyprlang config support is removed entirely** — discovery only finds `hyprland.lua` (verified in `Jeremy.cpp` at the locked rev), and even `--config foo.conf` is parsed as Lua. Hyprland ignored the home-manager `hyprland.conf`, wrote its example Lua config, and loaded that.

## What

**Lua migration** (`modules/home/hyprland/default.nix`)
- `configType = "lua"`: settings render as `hl.*()` calls; binds via `hl.dsp.*` dispatchers (mkLuaInline helpers); `bezier`/`animation` → `hl.curve`/`hl.animation`; structured `col` tables
- Special workspaces: `on_created_empty` rules + plain `toggle_special` binds replace the pgrep/hyprctl shell pipelines
- stylix hyprland target disabled — it still injects hyprlang dotted keys (`"col.active_border"`), invalid under the Lua renderer
- `tap-to-click`/`tap-and-drag` → underscore names
- **Verified**: `Hyprland --verify-config` against the exact store binary → `config ok`; full toplevel dry-run passes

**Macchiato-glass design pass** — one design language across the desktop: translucent mantle surfaces frosted by compositor blur (layer rules for waybar/rofi/dunst namespaces), 14–17px radii, state-only colors, and the mauve→teal→blue gradient as the single accent thread.
- **waybar**: three frosted islands (workspaces+window / clock / system), gradient active-workspace pill, named-workspace icons, mono numerals
- **rofi**: new module + `macchiato-glass.rasi` (gradient selection row); parse-checked with `rofi -dump-theme`
- **dunst**: glass card, gradient progress, proper urgency tiers, Mocha/Frappé color drift fixed, stale `Red-Rofi.rasi` dmenu reference removed
- **hyprlock**: gradient input-field ring (Barad-dûr identity untouched)

Also carries pre-existing working-tree WIP: uni-sync (Lian Li SL v1.2 fork pin), nvidia early KMS, teo cpuidle + nct6687 + openrgb on baradur, ssh `matchBlocks`→`settings`, ghostty arrow-key fix, kubectl hiPrio, vscode disabled, sops re-encrypt.

## Apply

`sudo nixos-rebuild switch --flake .#baradur` then log out/in (or `hyprctl reload` — the config path is unchanged). The stray autogenerated `~/.config/hypr/hyprland.lua` was already removed so activation won't collide.

## Smells noted for follow-up (not in this PR)

- **Ten ungated home modules** (`env, fonts, git, secrets, shell, ssh, theme, tmux, vscode, zed`) apply unconditionally to every home on every platform — this is the linux/darwin breakage surface. Suggest giving each an enable option (or splitting `modules/home` into `shared/` vs platform dirs) so darwin homes opt in explicitly.
- **Host hardware baked into shared modules**: waybar hardcodes `America/Vancouver`, `thermal-zone = 2`, and baradur's hwmon paths; should be host-level options.
- **Duplicated `permittedInsecurePackages`** in `flake.nix` and `modules/home/packages` — drift risk (they already disagree).
- **dbook/mingabook homebrew blocks in flake.nix are near-identical copies** — extract a shared darwin-host function.
- KB memory for the Hyprland gotcha: `/kb/memory/hyprland-master-lua-only-config`