### PR TITLE
feat(monitoring) grafana + prometheus + loki observability stack

### DIFF
--- a/modules/nixos/monitoring/default.nix
+++ b/modules/nixos/monitoring/default.nix
@@ -61,11 +61,7 @@ in
 
     networking.firewall.allowedTCPPorts = lib.optionals cfg.agent.openFirewall [ 9100 ];
 
-    services.alloy.enable = cfg.agent.lokiUrl != null;
-
-    # alloy runs with DynamicUser; journal read requires the group
-    systemd.services.alloy.serviceConfig.SupplementaryGroups =
-      lib.mkIf (cfg.agent.lokiUrl != null) [ "systemd-journal" ];
+    services.alloy.enable = lib.mkIf (cfg.agent.lokiUrl != null) true;
 
     environment.etc."alloy/config.alloy" = lib.mkIf (cfg.agent.lokiUrl != null) {
       text = ''

--- a/modules/nixos/monitoring/default.nix
+++ b/modules/nixos/monitoring/default.nix
@@ -1,0 +1,102 @@
+{ lib, config, namespace, ... }:
+let
+  cfg = config.${namespace}.monitoring;
+in
+{
+  imports = [ ./server.nix ];
+
+  options.${namespace}.monitoring = {
+    agent = {
+      enable = lib.mkEnableOption "node-level metrics + journal shipping (node_exporter + alloy)";
+
+      lokiUrl = lib.mkOption {
+        type = lib.types.nullOr lib.types.str;
+        default = null;
+        example = "http://10.0.30.2:3100";
+        description = "Loki base URL to ship the journal to; null disables log shipping.";
+      };
+
+      openFirewall = lib.mkOption {
+        type = lib.types.bool;
+        default = true;
+        description = "Open the node_exporter port (9100) so the monitoring server can scrape.";
+      };
+    };
+
+    server = {
+      enable = lib.mkEnableOption "monitoring server (Prometheus + Loki + Grafana + host exporters)";
+
+      grafanaPort = lib.mkOption {
+        type = lib.types.port;
+        default = 3000;
+      };
+
+      metricsRetention = lib.mkOption {
+        type = lib.types.str;
+        default = "365d";
+        description = "Prometheus TSDB retention.";
+      };
+
+      logRetention = lib.mkOption {
+        type = lib.types.str;
+        default = "2160h"; # 90d; Loki takes hours
+        description = "Loki log retention (compactor-enforced).";
+      };
+
+      nodeTargets = lib.mkOption {
+        type = lib.types.listOf lib.types.str;
+        default = [ ];
+        example = [ "10.0.30.11:9100" ];
+        description = "node_exporter scrape targets beyond localhost (host:port).";
+      };
+    };
+  };
+
+  config = lib.mkIf cfg.agent.enable {
+    services.prometheus.exporters.node = {
+      enable = true;
+      port = 9100;
+      enabledCollectors = [ "systemd" "processes" ];
+    };
+
+    networking.firewall.allowedTCPPorts = lib.optionals cfg.agent.openFirewall [ 9100 ];
+
+    services.alloy.enable = cfg.agent.lokiUrl != null;
+
+    # alloy runs with DynamicUser; journal read requires the group
+    systemd.services.alloy.serviceConfig.SupplementaryGroups =
+      lib.mkIf (cfg.agent.lokiUrl != null) [ "systemd-journal" ];
+
+    environment.etc."alloy/config.alloy" = lib.mkIf (cfg.agent.lokiUrl != null) {
+      text = ''
+        loki.relabel "journal" {
+          forward_to = []
+          rule {
+            source_labels = ["__journal__systemd_unit"]
+            target_label  = "unit"
+          }
+          rule {
+            source_labels = ["__journal__transport"]
+            target_label  = "transport"
+          }
+          rule {
+            source_labels = ["__journal_priority_keyword"]
+            target_label  = "level"
+          }
+        }
+
+        loki.source.journal "journal" {
+          relabel_rules = loki.relabel.journal.rules
+          forward_to    = [loki.write.default.receiver]
+          labels        = {job = "systemd-journal", host = "${config.networking.hostName}"}
+        }
+
+        loki.write.default {
+          endpoint {
+            url = "${cfg.agent.lokiUrl}/loki/api/v1/push"
+          }
+        }
+      '';
+    };
+  };
+}

--- a/modules/nixos/monitoring/server.nix
+++ b/modules/nixos/monitoring/server.nix
@@ -3,5 +3,86 @@ let
   cfg = config.${namespace}.monitoring;
 in
 {
-  config = lib.mkIf cfg.server.enable { };
+  config = lib.mkIf cfg.server.enable {
+    services.prometheus = {
+      enable = true;
+      listenAddress = "127.0.0.1";
+      port = 9090;
+      retentionTime = cfg.server.metricsRetention;
+
+      globalConfig = {
+        scrape_interval = "15s";
+        evaluation_interval = "15s";
+      };
+
+      exporters = {
+        smartctl.enable = true;   # 9633 — NVMe/SATA health, auto-discovers devices
+        nvidia-gpu.enable = true; # 9835 — wraps nvidia-smi
+        systemd.enable = true;    # 9558 — per-unit states + cgroup resources
+
+        wireguard = lib.mkIf config.${namespace}.wireguard.enable {
+          enable = true;          # 9586 — per-peer handshake/transfer
+        };
+
+        blackbox = {
+          enable = true;          # 9115
+          configFile = pkgs.writeText "blackbox.yml" (builtins.toJSON {
+            modules = {
+              icmp.prober = "icmp";
+              dns_quad9 = {
+                prober = "dns";
+                dns = {
+                  query_name = "google.com";
+                  query_type = "A";
+                  transport_protocol = "udp";
+                };
+              };
+            };
+          });
+        };
+      };
+
+      scrapeConfigs = [
+        {
+          job_name = "node";
+          static_configs = [ { targets = [ "127.0.0.1:9100" ] ++ cfg.server.nodeTargets; } ];
+        }
+        { job_name = "smartctl";   static_configs = [ { targets = [ "127.0.0.1:9633" ]; } ]; }
+        { job_name = "nvidia_gpu"; static_configs = [ { targets = [ "127.0.0.1:9835" ]; } ]; }
+        { job_name = "systemd";    static_configs = [ { targets = [ "127.0.0.1:9558" ]; } ]; }
+        { job_name = "prometheus"; static_configs = [ { targets = [ "127.0.0.1:9090" ]; } ]; }
+        { job_name = "loki";       static_configs = [ { targets = [ "127.0.0.1:3100" ]; } ]; }
+        {
+          job_name = "blackbox_icmp";
+          metrics_path = "/probe";
+          params.module = [ "icmp" ];
+          static_configs = [ { targets = [ "1.1.1.1" "9.9.9.9" ]; } ];
+          relabel_configs = [
+            { source_labels = [ "__address__" ]; target_label = "__param_target"; }
+            { source_labels = [ "__param_target" ]; target_label = "instance"; }
+            { target_label = "__address__"; replacement = "127.0.0.1:9115"; }
+          ];
+        }
+        {
+          job_name = "blackbox_dns";
+          metrics_path = "/probe";
+          params.module = [ "dns_quad9" ];
+          static_configs = [ { targets = [ "9.9.9.9" ]; } ];
+          relabel_configs = [
+            { source_labels = [ "__address__" ]; target_label = "__param_target"; }
+            { source_labels = [ "__param_target" ]; target_label = "instance"; }
+            { target_label = "__address__"; replacement = "127.0.0.1:9115"; }
+          ];
+        }
+      ]
+      ++ lib.optionals config.${namespace}.wireguard.enable [
+        { job_name = "wireguard"; static_configs = [ { targets = [ "127.0.0.1:9586" ]; } ]; }
+      ];
+    };
+
+    # per-unit CPU/memory/IO for the systemd exporter — `systemd.enableCgroupAccounting` was
+    # removed on this pinned nixpkgs (mkRemovedOptionModule, see systemd.nix); cgroup CPU/memory/
+    # tasks accounting is on by default in modern systemd, and NixOS now sets
+    # DefaultIOAccounting/DefaultIPAccounting = true itself, so no replacement setting is needed.
+  };
 }

--- a/modules/nixos/monitoring/server.nix
+++ b/modules/nixos/monitoring/server.nix
@@ -1,6 +1,21 @@
 { lib, config, namespace, pkgs, ... }:
 let
   cfg = config.${namespace}.monitoring;
+
+  nodeExporterDashboard = pkgs.fetchurl {
+    url = "https://grafana.com/api/dashboards/1860/revisions/37/download";
+    hash = "sha256-1DE1aaanRHHeCOMWDGdOS1wBXxOF84UXAjJzT5Ek6mM=";
+  };
+  nvidiaDashboard = pkgs.fetchurl {
+    url = "https://grafana.com/api/dashboards/14574/revisions/4/download";
+    hash = "sha256-P2klydQSVc+P5RBBXE+OS4D1D0nJzC49gQYI//qTaZ8=";
+  };
+  # community dashboards ship "${DS_PROMETHEUS}" input placeholders; pin them to our uid
+  dashboardsDir = pkgs.runCommand "grafana-dashboards" { } ''
+    mkdir -p $out
+    sed -e 's/''${DS_PROMETHEUS}/prometheus/g' ${nodeExporterDashboard} > $out/node-exporter-full.json
+    sed -e 's/''${DS_PROMETHEUS}/prometheus/g' ${nvidiaDashboard}       > $out/nvidia-gpu.json
+  '';
 in
 {
   config = lib.mkIf cfg.server.enable {
@@ -84,5 +99,85 @@ in
     # removed on this pinned nixpkgs (mkRemovedOptionModule, see systemd.nix); cgroup CPU/memory/
     # tasks accounting is on by default in modern systemd, and NixOS now sets
     # DefaultIOAccounting/DefaultIPAccounting = true itself, so no replacement setting is needed.
+
+    services.loki = {
+      enable = true;
+      configuration = {
+        auth_enabled = false;
+        server = {
+          http_listen_address = "0.0.0.0";
+          http_listen_port = 3100;
+          grpc_listen_address = "127.0.0.1";
+        };
+        common = {
+          replication_factor = 1;
+          path_prefix = "/var/lib/loki";
+          ring = {
+            kvstore.store = "inmemory";
+            instance_addr = "127.0.0.1";
+          };
+        };
+        schema_config.configs = [
+          {
+            from = "2026-01-01";
+            store = "tsdb";
+            object_store = "filesystem";
+            schema = "v13";
+            index = { prefix = "index_"; period = "24h"; };
+          }
+        ];
+        storage_config.filesystem.directory = "/var/lib/loki/chunks";
+        compactor = {
+          working_directory = "/var/lib/loki/compactor";
+          retention_enabled = true;
+          delete_request_store = "filesystem";
+        };
+        limits_config.retention_period = cfg.server.logRetention;
+      };
+    };
+
+    services.grafana = {
+      enable = true;
+      settings = {
+        server = {
+          http_addr = "0.0.0.0";
+          http_port = cfg.server.grafanaPort;
+        };
+        analytics.reporting_enabled = false;
+        # nixpkgs 26.05 removed the default for security.secret_key (was previously implicit).
+        # Neither provisioned datasource carries credentials, so there is nothing in the DB
+        # yet that this key protects; using the documented legacy default is upstream's own
+        # zero-risk path for that case. Before storing any datasource secrets in Grafana,
+        # replace this with a generated key via a file-provider (e.g. sops-nix), since keys
+        # cannot be rotated without re-encrypting existing secrets.
+        security.secret_key = "SW2YcwTIb9zpOOhoPsMm";
+      };
+      provision = {
+        enable = true;
+        datasources.settings.datasources = [
+          {
+            name = "Prometheus";
+            uid = "prometheus";
+            type = "prometheus";
+            url = "http://127.0.0.1:9090";
+            isDefault = true;
+          }
+          {
+            name = "Loki";
+            uid = "loki";
+            type = "loki";
+            url = "http://127.0.0.1:3100";
+          }
+        ];
+        dashboards.settings.providers = [
+          {
+            name = "vendored";
+            options.path = dashboardsDir;
+          }
+        ];
+      };
+    };
+
+    networking.firewall.allowedTCPPorts = [ cfg.server.grafanaPort 3100 ];
   };
 }

--- a/modules/nixos/monitoring/server.nix
+++ b/modules/nixos/monitoring/server.nix
@@ -1,0 +1,7 @@
+{ lib, config, namespace, pkgs, ... }:
+let
+  cfg = config.${namespace}.monitoring;
+in
+{
+  config = lib.mkIf cfg.server.enable { };
+}

--- a/modules/nixos/monitoring/server.nix
+++ b/modules/nixos/monitoring/server.nix
@@ -10,11 +10,13 @@ let
     url = "https://grafana.com/api/dashboards/14574/revisions/4/download";
     hash = "sha256-P2klydQSVc+P5RBBXE+OS4D1D0nJzC49gQYI//qTaZ8=";
   };
-  # community dashboards ship "${DS_PROMETHEUS}" input placeholders; pin them to our uid
+  # nvidia ships "${DS_PROMETHEUS}" input placeholders; node-exporter-full uses "${datasource}"
+  # template vars that resolve via the isDefault datasource. Pin placeholders AND the legacy
+  # hard-coded "000000001" row uids to our uid so future revision bumps can't dangle.
   dashboardsDir = pkgs.runCommand "grafana-dashboards" { } ''
     mkdir -p $out
-    sed -e 's/''${DS_PROMETHEUS}/prometheus/g' ${nodeExporterDashboard} > $out/node-exporter-full.json
-    sed -e 's/''${DS_PROMETHEUS}/prometheus/g' ${nvidiaDashboard}       > $out/nvidia-gpu.json
+    sed -e 's/''${DS_PROMETHEUS}/prometheus/g' -e 's/"000000001"/"prometheus"/g' ${nodeExporterDashboard} > $out/node-exporter-full.json
+    sed -e 's/''${DS_PROMETHEUS}/prometheus/g' -e 's/"000000001"/"prometheus"/g' ${nvidiaDashboard}       > $out/nvidia-gpu.json
   '';
 in
 {

--- a/modules/nixos/worker/default.nix
+++ b/modules/nixos/worker/default.nix
@@ -70,6 +70,11 @@ in
   };
 
   config = lib.mkIf cfg.enable {
+    ${namespace}.monitoring.agent = {
+      enable = lib.mkDefault true;
+      lokiUrl = lib.mkDefault "http://${cfg.bootServer}:3100";
+    };
+
     assertions = [
       {
         assertion = cfg.k3s.role == "server" -> cfg.k3s.target == null;

--- a/systems/aarch64-linux/agent/default.nix
+++ b/systems/aarch64-linux/agent/default.nix
@@ -18,6 +18,8 @@
 
   networking = { };
 
+  fellowship.monitoring.agent.enable = true;
+
   nix = {
     settings.experimental-features = "nix-command flakes";
     gc = {

--- a/systems/aarch64-linux/helms-deep/default.nix
+++ b/systems/aarch64-linux/helms-deep/default.nix
@@ -62,6 +62,9 @@
       uplinkInterface = "eth0";
     };
 
+    monitoring.agent.enable = true;
+    # lokiUrl stays null until baradur has a static LAN address helms-deep can reach
+
     microvm = {
       enable = true;
       bridgeInterface = "br0";

--- a/systems/x86_64-linux/baradur/default.nix
+++ b/systems/x86_64-linux/baradur/default.nix
@@ -117,6 +117,18 @@
       ];
       privateKeyFile = config.sops.secrets."vpn/wg/privateKey".path;
     };
+
+    monitoring = {
+      agent = {
+        enable = true;
+        openFirewall = false;              # scraper is local
+        lokiUrl = "http://127.0.0.1:3100"; # Loki lands in Task 3
+      };
+      server = {
+        enable = true;
+        nodeTargets = [ ]; # follow-up: helms-deep + pi workers once static addresses exist
+      };
+    };
   };
 
   environment = {


### PR DESCRIPTION
## Summary

Systemd-native observability for the fellowship — no Docker anywhere:

- New `fellowship.monitoring` module with two roles:
  - **agent** — node_exporter (systemd/processes collectors) + Alloy shipping the full journald stream (kernel ring buffer included) to Loki, labeled host/unit/transport/level
  - **server** — Prometheus (`127.0.0.1:9090`, 365d retention, 15s scrape) + Loki (`0.0.0.0:3100`, 90d compactor-enforced retention) + Grafana (`0.0.0.0:3000`) + smartctl / nvidia-gpu / systemd / wireguard / blackbox exporters
- Hosts: **baradur** = server+agent; **helms-deep** + **agent** SD image = agents; netboot **workers** default to agent with `lokiUrl` derived from `bootServer`
- Dashboards vendored at build time (Node Exporter Full #1860, NVIDIA GPU #14574) with datasource uids pinned; Prometheus + Loki datasources provisioned declaratively

## Verification

- `nix eval` of baradur / helms-deep / agent toplevels + full `nix build` of the baradur closure, green on final HEAD (build-time promtool + blackbox config checks included)
- Per-task agent reviews + whole-branch final review clean; realized store outputs (loki config, grafana provisioning, dashboard JSONs) inspected
- Worker+monitoring composition verified via ad-hoc `extendModules` eval (no worker host in `systems/` yet)

## Post-merge notes

- First switch brings Grafana up as `admin`/`admin` on `:3000` — **change it at first login**; sops-backed password + `security.secret_key` are tracked follow-ups (key is currently the upstream-sanctioned default; nothing encrypted with it yet)
- Remote metrics scraping needs static IPs in `fellowship.monitoring.server.nodeTargets` (+ `lokiUrl` on helms-deep)
- Commits are unsigned on this branch (sandboxed agents can't drive pinentry) — re-sign via squash if desired
- Deviations from plan, both verified against the nixpkgs pin: `systemd.enableCgroupAccounting` removed upstream (accounting default-on); explicit `secret_key` newly asserted by nixpkgs

https://claude.ai/code/session_013JDskYYQe1wwFj3UvAfRZ2