### PR TITLE
fix(monitoring) alloy loki.write declaration syntax

### DIFF
--- a/modules/nixos/monitoring/default.nix
+++ b/modules/nixos/monitoring/default.nix
@@ -87,7 +87,7 @@ in
           labels        = {job = "systemd-journal", host = "${config.networking.hostName}"}
         }
 
-        loki.write.default {
+        loki.write "default" {
           endpoint {
             url = "${cfg.agent.lokiUrl}/loki/api/v1/push"
           }


### PR DESCRIPTION
One-line fix for the alloy.service crash-loop after switching to the monitoring stack (#7).

**Root cause:** River block declarations take their label as a quoted string — `loki.write "default" { … }` — but the config used the dotted *reference* form `loki.write.default { … }` in the declaration position. Alloy's component-graph load fails with `cannot find the definition of component name "loki.write.default"` and the service exits 1 on a restart loop. The other two blocks were declared correctly; this was a plan-authoring bug that no build-time check catches (alloy configs aren't validated at build — flagged as the one unverifiable item in review).

**Verification:** rebuilt the baradur toplevel and ran the unit's own alloy 1.17.1 binary against the newly rendered `/etc/alloy/config.alloy` (isolated port + storage): graph loads, `loki.source.journal` / `loki.relabel` / `loki.write` all start; ran until the test timeout killed it, exit via SIGTERM only.

Commit is unsigned for the same sandbox/pinentry reason as #7 — squash-merge re-authors it anyway.

https://claude.ai/code/session_013JDskYYQe1wwFj3UvAfRZ2