### PR TITLE
feat(worker) worker fleet netboot — baradur boot provider + pi k3s hosts

### DIFF
--- a/.sops.yaml
+++ b/.sops.yaml
@@ -6,6 +6,8 @@ keys:
   - &mingabook age14ejy4tppggtacyzxfhtnagqhtr60zyf6l6euh5vxlf8uh9vcef3s2clada
   - &darrenbangsund age1fyndjw4ucc39hh2kyuxth2pyevl2h5zh9lmfq7v9h8neq9csnc9qrcm4zq
   - &helms-deep PLACEHOLDER_AGE_PUBLIC_KEY
+  - &worker PLACEHOLDER_AGE_PUBLIC_KEY
+  - &agent PLACEHOLDER_AGE_PUBLIC_KEY
 creation_rules:
   - path_regex: secrets/arrayofone.yaml$
     key_groups:
@@ -35,3 +37,16 @@ creation_rules:
     key_groups:
       - age:
           - *helms-deep
+  - path_regex: secrets/worker.yaml$
+    key_groups:
+      - age:
+          - *worker
+  - path_regex: secrets/agent.yaml$
+    key_groups:
+      - age:
+          - *agent
+  # bootstrap: add *worker, *agent to this group + sops updatekeys
+  - path_regex: secrets/k3s-cluster.yaml$
+    key_groups:
+      - age:
+          - *arrayofone

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -431,6 +431,101 @@ tasks:
       - nixos-rebuild switch --flake {{.FLAKE_DIR}}#{{.MICROVM_HOST}} --target-host root@{{.MICROVM_HOST}} --show-trace --verbose
 
   # =============================================================================
+  # NETBOOT ARTIFACT PIPELINE (worker fleet)
+  # =============================================================================
+
+  netboot:host:
+    desc: "Build a worker's netboot artifacts and atomically publish to TFTP"
+    # MODE = nfs | ram. The host must set boot.loader.raspberry-pi.bootloader = "kernel".
+    vars: { HOST: '{{.HOST}}', MAC: '{{.MAC}}', MODE: '{{.MODE}}' }
+    cmds:
+      - |
+        set -euo pipefail
+        test -e /proc/sys/fs/binfmt_misc/qemu-aarch64 || { echo "binfmt inactive — switch baradur first"; exit 1; }
+
+        C=".#nixosConfigurations.{{.HOST}}.config"
+        DST=/srv/netboot/{{.MAC}}            # matches tftp-unique-root=mac (lowercase, colon-sep)
+        GEN="$DST/$(date +%s)"; mkdir -p "$GEN"
+
+        # kernel (REAL attr); initrd differs by mode: ram = netbootRamdisk (store baked in).
+        KERNEL=$(nix build --no-link --print-out-paths "$C.system.build.kernel")
+        if [ "{{.MODE}}" = "ram" ]; then
+          INITRD=$(nix build --no-link --print-out-paths "$C.system.build.netbootRamdisk")
+        else
+          INITRD=$(nix build --no-link --print-out-paths "$C.system.build.initialRamdisk")
+        fi
+        install -Dm644 "$KERNEL/Image"  "$GEN/Image"
+        install -Dm644 "$INITRD/initrd" "$GEN/initrd"
+
+        # firmware blobs (start4.elf, fixup4.dat, *.dtb, overlays/) — NO `|| true`, fail loudly.
+        # Vendor-vs-mainline is host-specific (see T1/T5 commit bodies) — try the vendor
+        # firmwarePackage first; if it doesn't evaluate, fall back to nixpkgs#raspberrypifw and
+        # hand-write config.txt (raspberrypifw ships no config.txt of its own).
+        if FW=$(nix build --no-link --print-out-paths "$C.boot.loader.raspberry-pi.firmwarePackage" 2>/dev/null); then
+          cp -r "$FW"/share/raspberrypi/boot/* "$GEN/"
+          CFG=$(nix build --no-link --print-out-paths "$C.boot.loader.raspberry-pi.configTxtPackage")
+          cp "$CFG/config.txt" "$GEN/config.txt"
+        else
+          echo "vendor firmwarePackage did not evaluate for {{.HOST}} — falling back to nixpkgs#raspberrypifw"
+          FW=$(nix build --no-link --print-out-paths nixpkgs#raspberrypifw)
+          cp -r "$FW"/share/raspberrypi/boot/* "$GEN/"
+          cat > "$GEN/config.txt" <<'CFGEOF'
+        kernel=Image
+        initramfs initrd followkernel
+        enable_uart=1
+        arm_64bit=1
+        CFGEOF
+        fi
+
+        # ensure config.txt names the kernel we installed ("Image") + the initrd:
+        grep -q '^kernel=Image' "$GEN/config.txt" || echo "kernel=Image"            >> "$GEN/config.txt"
+        grep -q '^initramfs initrd' "$GEN/config.txt" || echo "initramfs initrd followkernel" >> "$GEN/config.txt"
+
+        # cmdline.txt — DRY: derive from the host's own kernelParams (set by root.nix nfs branch).
+        nix eval --raw "$C.boot.kernelParams" --apply 'ps: builtins.concatStringsSep " " ps' \
+          | sed 's/$/ console=tty1 console=serial0,115200/' > "$GEN/cmdline.txt"
+
+        # HARD ASSERT a bootable set before publishing — never flip `current` to a broken tree.
+        for f in start4.elf fixup4.dat config.txt cmdline.txt Image initrd; do
+          test -s "$GEN/$f" || { echo "MISSING $f — refusing to publish"; exit 1; }
+        done
+
+        ln -sfn "$GEN" "$DST/current"        # atomic publish
+        ls -dt "$DST"/[0-9]* | tail -n +4 | xargs -r rm -rf   # keep last 3 generations
+
+  netboot:sdimage:
+    desc: "Build a host's sdImage artifact and print the flashing hint"
+    # ON-HARDWARE-VALIDATE: under the vendor modules confirm the sdImage attr and that its boot
+    # partition layout matches Pi 4/5 firmware expectations.
+    vars: { HOST: '{{.HOST}}' }
+    cmds:
+      - |
+        set -euo pipefail
+        test -e /proc/sys/fs/binfmt_misc/qemu-aarch64 || { echo "binfmt inactive — switch baradur first"; exit 1; }
+        IMG=$(nix build --no-link --print-out-paths .#nixosConfigurations.{{.HOST}}.config.system.build.sdImage)
+        echo "sdImage built: $IMG"
+        echo "Flash: sudo dd if=$IMG/sd-image/*.img of=/dev/sdX bs=4M status=progress conv=fsync"
+        echo "See docs/superpowers/plans/2026-06-21-pi-netboot-runbook.md for the full flashing/EEPROM procedure."
+
+  netboot:seed:
+    desc: "Pre-seed a host's SSH host key + age identity before first boot"
+    vars: { HOST: '{{.HOST}}' }
+    cmds:
+      - mkdir -p /tmp/{{.HOST}}-seed && ssh-keygen -t ed25519 -N "" -f /tmp/{{.HOST}}-seed/ssh_host_ed25519_key && nix shell nixpkgs#ssh-to-age -c sh -c 'ssh-to-age < /tmp/{{.HOST}}-seed/ssh_host_ed25519_key.pub'
+      - echo "Follow-ups — replace the .sops.yaml placeholder for {{.HOST}} with the age key printed above, then:"
+      - echo "  sops updatekeys secrets/k3s-cluster.yaml"
+      - echo "  create secrets/{{.HOST}}.yaml (per the runbook)"
+      - echo "  copy /tmp/{{.HOST}}-seed/ssh_host_ed25519_key(.pub) into the state device's ssh/ dir"
+
+  kubeconfig:fetch:
+    desc: "Pull k3s kubeconfig from the worker and point it at the VLAN IP"
+    vars: { IP: '{{.IP}}' } # worker VLAN IP
+    cmds:
+      - mkdir -p ~/.kube
+      - ssh arrayofone@{{.IP}} sudo cat /etc/rancher/k3s/k3s.yaml | sed 's#https://127.0.0.1:6443#https://{{.IP}}:6443#' > ~/.kube/worker.yaml
+      - echo "export KUBECONFIG=~/.kube/worker.yaml"
+
+  # =============================================================================
   # HELP & SHORTCUTS
   # =============================================================================
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -447,7 +447,7 @@ tasks:
         DST=/srv/netboot/{{.MAC}}            # matches tftp-unique-root=mac (lowercase, colon-sep)
         GEN="$DST/$(date +%s)"; mkdir -p "$GEN"
 
-        # kernel (REAL attr); initrd differs by mode: ram = netbootRamdisk (store baked in).
+        # kernel (REAL attr); initrd differs by mode: ram = netbootRamdisk (store baked in).  [fix: re#F1/F2]
         KERNEL=$(nix build --no-link --print-out-paths "$C.system.build.kernel")
         if [ "{{.MODE}}" = "ram" ]; then
           INITRD=$(nix build --no-link --print-out-paths "$C.system.build.netbootRamdisk")
@@ -457,7 +457,7 @@ tasks:
         install -Dm644 "$KERNEL/Image"  "$GEN/Image"
         install -Dm644 "$INITRD/initrd" "$GEN/initrd"
 
-        # firmware blobs (start4.elf, fixup4.dat, *.dtb, overlays/) — NO `|| true`, fail loudly.
+        # firmware blobs (start4.elf, fixup4.dat, *.dtb, overlays/) — NO `|| true`, fail loudly.  [fix: re#B1]
         # Vendor-vs-mainline is host-specific (see T1/T5 commit bodies) — try the vendor
         # firmwarePackage first; if it doesn't evaluate, fall back to nixpkgs#raspberrypifw and
         # hand-write config.txt (raspberrypifw ships no config.txt of its own).
@@ -481,17 +481,17 @@ tasks:
         grep -q '^kernel=Image' "$GEN/config.txt" || echo "kernel=Image"            >> "$GEN/config.txt"
         grep -q '^initramfs initrd' "$GEN/config.txt" || echo "initramfs initrd followkernel" >> "$GEN/config.txt"
 
-        # cmdline.txt — DRY: derive from the host's own kernelParams (set by root.nix nfs branch).
+        # cmdline.txt — DRY: derive from the host's own kernelParams (set by root.nix nfs branch).  [fix: re#F4]
         nix eval --raw "$C.boot.kernelParams" --apply 'ps: builtins.concatStringsSep " " ps' \
           | sed 's/$/ console=tty1 console=serial0,115200/' > "$GEN/cmdline.txt"
 
-        # HARD ASSERT a bootable set before publishing — never flip `current` to a broken tree.
+        # HARD ASSERT a bootable set before publishing — never flip `current` to a broken tree.  [fix: re#B1]
         for f in start4.elf fixup4.dat config.txt cmdline.txt Image initrd; do
           test -s "$GEN/$f" || { echo "MISSING $f — refusing to publish"; exit 1; }
         done
 
         ln -sfn "$GEN" "$DST/current"        # atomic publish
-        ls -dt "$DST"/[0-9]* | tail -n +4 | xargs -r rm -rf   # keep last 3 generations
+        ls -dt "$DST"/[0-9]* | tail -n +4 | xargs -r rm -rf   # keep last 3 generations  [fix: re#B6]
 
   netboot:sdimage:
     desc: "Build a host's sdImage artifact and print the flashing hint"
@@ -522,7 +522,7 @@ tasks:
     vars: { IP: '{{.IP}}' } # worker VLAN IP
     cmds:
       - mkdir -p ~/.kube
-      - ssh arrayofone@{{.IP}} sudo cat /etc/rancher/k3s/k3s.yaml | sed 's#https://127.0.0.1:6443#https://{{.IP}}:6443#' > ~/.kube/worker.yaml
+      - ssh arrayofone@{{.IP}} sudo cat /etc/rancher/k3s/k3s.yaml | sed 's#https://127.0.0.1:6443#https://{{.IP}}:6443#' > ~/.kube/worker.yaml   # [fix: re#B2]
       - echo "export KUBECONFIG=~/.kube/worker.yaml"
 
   # =============================================================================

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -436,7 +436,9 @@ tasks:
 
   netboot:host:
     desc: "Build a worker's netboot artifacts and atomically publish to TFTP"
-    # MODE = nfs | ram. The host must set boot.loader.raspberry-pi.bootloader = "kernel".
+    # MODE = nfs | ram. Vendor hosts would set boot.loader.raspberry-pi.bootloader = "kernel";
+    # under the 2026-08-01 mainline verdict the firmware boots kernel=Image directly and no
+    # bootloader option applies.
     vars: { HOST: '{{.HOST}}', MAC: '{{.MAC}}', MODE: '{{.MODE}}' }
     cmds:
       - |
@@ -444,7 +446,7 @@ tasks:
         test -e /proc/sys/fs/binfmt_misc/qemu-aarch64 || { echo "binfmt inactive — switch baradur first"; exit 1; }
 
         C=".#nixosConfigurations.{{.HOST}}.config"
-        DST=/srv/netboot/{{.MAC}}            # matches tftp-unique-root=mac (lowercase, colon-sep)
+        DST=/srv/netboot/{{.MAC}}            # matches tftp-unique-root=mac (lowercase, dash-separated — dnsmasq appends e.g. dc-a6-32-01-02-03)
         GEN="$DST/$(date +%s)"; mkdir -p "$GEN"
 
         # kernel (REAL attr); initrd differs by mode: ram = netbootRamdisk (store baked in).  [fix: re#F1/F2]
@@ -456,6 +458,9 @@ tasks:
         fi
         install -Dm644 "$KERNEL/Image"  "$GEN/Image"
         install -Dm644 "$INITRD/initrd" "$GEN/initrd"
+
+        # toplevel — needed for init= on the kernel cmdline (stage-1 execs it).  [fix: re#F3]
+        TOPLEVEL=$(nix build --no-link --print-out-paths "$C.system.build.toplevel")
 
         # firmware blobs (start4.elf, fixup4.dat, *.dtb, overlays/) — NO `|| true`, fail loudly.  [fix: re#B1]
         # Vendor-vs-mainline is host-specific (see T1/T5 commit bodies) — try the vendor
@@ -469,6 +474,9 @@ tasks:
           echo "vendor firmwarePackage did not evaluate for {{.HOST}} — falling back to nixpkgs#raspberrypifw"
           FW=$(nix build --no-link --print-out-paths nixpkgs#raspberrypifw)
           cp -r "$FW"/share/raspberrypi/boot/* "$GEN/"
+          # mainline kernel pairs with mainline DTBs — overwrite the vendor blobs' copies; the
+          # firmware patches whichever DTB sits in the boot dir. ON-HARDWARE-VALIDATE (Pi 5 especially).  [deep-review]
+          find "$KERNEL/dtbs/broadcom" \( -name 'bcm2711-rpi-4-*.dtb' -o -name 'bcm2712-rpi-5-*.dtb' \) -exec cp -f {} "$GEN/" \;
           cat > "$GEN/config.txt" <<'CFGEOF'
         kernel=Image
         initramfs initrd followkernel
@@ -482,8 +490,9 @@ tasks:
         grep -q '^initramfs initrd' "$GEN/config.txt" || echo "initramfs initrd followkernel" >> "$GEN/config.txt"
 
         # cmdline.txt — DRY: derive from the host's own kernelParams (set by root.nix nfs branch).  [fix: re#F4]
+        # init= is mandatory — stage-1 execs the toplevel's init; without it the boot dead-ends.  [deep-review]
         nix eval --raw "$C.boot.kernelParams" --apply 'ps: builtins.concatStringsSep " " ps' \
-          | sed 's/$/ console=tty1 console=serial0,115200/' > "$GEN/cmdline.txt"
+          | sed "s|\$| console=tty1 console=serial0,115200 init=$TOPLEVEL/init|" > "$GEN/cmdline.txt"
 
         # HARD ASSERT a bootable set before publishing — never flip `current` to a broken tree.  [fix: re#B1]
         for f in start4.elf fixup4.dat config.txt cmdline.txt Image initrd; do

--- a/docs/superpowers/plans/2026-06-21-pi-netboot-runbook.md
+++ b/docs/superpowers/plans/2026-06-21-pi-netboot-runbook.md
@@ -5,40 +5,115 @@ actual Pi(s) + UniFi access. Companion to `2026-06-21-pi-netboot-k3s-worker.md`.
 
 ## Status
 
-- **Done (software infra, this PR):** `nixos-raspberrypi` flake input; `fellowship.netboot`
-  module (proxy-DHCP + TFTP + NFSv4 + scripted VLAN + binfmt); `fellowship.worker` module
-  (k3s, `/state` device + binds, `root.mode` ram/nfs/local). Both modules ship **inert**
-  (`enable = false`) — no host enables them yet.
-- **Deferred (needs the Pi + UniFi):** instantiate the `worker` (Pi 4) and `agent` (Pi 5)
-  hosts; pre-seed sops identity; enable `fellowship.netboot` on baradur; the netboot
-  artifact `Taskfile` target; all hardware bring-up.
+- **Done (software infra):** `nixos-raspberrypi` flake input; `fellowship.netboot` module
+  (proxy-DHCP + TFTP + NFSv4 + scripted VLAN + binfmt + arch-aware/EFI clients); `fellowship.worker`
+  module (k3s, `/state` device + binds, `root.mode` ram/nfs/local, NFS StorageClass + etcd
+  snapshots). `fellowship.netboot` is **enabled on baradur** (`enp42s0` / VLAN 30, settled
+  addresses below). The `worker` (Pi 4) and `agent` (Pi 5) hosts exist in-repo, bootstrap-ladder
+  rung `local`, `fellowship.worker.enable = true`. The `netboot:*`/`kubeconfig:fetch` Taskfile
+  targets exist.
+  **Kernel verdict:** RED — `nixos-raspberrypi`'s vendor modules (`raspberry-pi-4.base` /
+  `raspberry-pi-5.base`) don't evaluate under this flake's Snowfall-driven `specialArgs`
+  (they require a `nixos-raspberrypi` special arg bound to the vendor flake's own `self`,
+  which Snowfall Lib's system builder never provides). Both hosts run the mainline kernel
+  (`boot.loader.generic-extlinux-compatible`) — see the `worker` host's commit body for the
+  exact eval error, should a future retest be worth another look.
+- **Deferred (needs the Pi + UniFi, this doc):** pre-seed sops identity per host; UniFi VLAN
+  + firewall; flash + EEPROM; first boot; kubeconfig fetch; all hardware bring-up below.
+
+## Settled values
+
+| Item | Value |
+| --- | --- |
+| VLAN | 30, on `enp42s0` (iface `enp42s0.30`) |
+| baradur (netboot server) | `10.0.30.2/24` |
+| worker — Pi 4, k3s server | `10.0.30.11` |
+| agent — Pi 5, k3s agent | `10.0.30.12` |
+| `rootStore` (NFS root export, `nfs` mode) | `/mnt/node/netboot-roots` |
+| `pvcExport` (NFS PVC + etcd-snapshot export) | `/mnt/node/k8s-pvcs` |
+
+## Bootstrap ladder (`root.mode`)
+
+Each host file (`systems/aarch64-linux/{worker,agent}/default.nix`) has a single
+`let rootMode = "local";` binding, marked `# BOOTSTRAP LADDER`. Advance one rung at a time —
+edit `rootMode`, redeploy per that rung, verify on hardware, **then** commit the flip. Never
+skip a rung (don't jump straight to `ram` without proving `nfs`, or `nfs` without proving
+`local`).
+
+1. **`local`** — Pi boots off its own on-disk root (`NIXOS_SD` label). Normal on-disk install.
+2. **`nfs`** — kernel-driven NFS root (busybox stage-1 has no `mount.nfs`), served from
+   baradur's `rootStore`. Proves the netboot chain end-to-end.
+3. **`ram`** — TFTP-loaded RAM root (`netbootRamdisk`; the Nix store squashfs is baked into
+   the initrd, no runtime NFS). The resilient default: once booted, a baradur reboot can't
+   touch a running node.
+
+Deploy command per rung — see "Per-mode deploy loop" below; never `nixos-rebuild switch` **on**
+a Pi once it's off `local`.
+
+## The binfmt gate
+
+Nothing aarch64 builds on baradur — not `worker`/`agent` toplevel, not sdImages, not netboot
+artifacts — until **baradur's own first `switch`** activates `fellowship.netboot`'s binfmt
+registration (`/proc/sys/fs/binfmt_misc/qemu-aarch64` is empty until then). Every
+`task netboot:*` target checks that path first and exits 1 if it's missing. So the first
+hardware step, always, is switching baradur (UniFi step 5 / bootstrap step 1 below) —
+everything aarch64 depends on it transitively.
 
 ## UniFi / switch (Phase 1)
 
-1. Create a VLAN-only network "worker" with id = `fellowship.netboot.vlan`; DHCP **on**,
+1. Create a VLAN-only network "worker", **VLAN id 30** (`fellowship.netboot.vlan`); DHCP **on**,
    **Network-Boot OFF** (else two boot responders collide with baradur's proxy-DHCP).
-2. Reserve a static lease per Pi → fills `fellowship.netboot.clients.<host>.address`.
+2. Reserve a static lease per Pi: worker (Pi 4) → **10.0.30.11**, agent (Pi 5) → **10.0.30.12**
+   (already set as `fellowship.netboot.clients.<host>.address` on baradur; only the `mac`
+   fields are blank in-repo — filled in from dnsmasq's logs at each Pi's first PXE attempt,
+   then committed).
 3. Tag baradur's switch port for the worker VLAN (trusted VLAN stays untagged).
 4. Set each **Pi's** switch port to **untagged / access = worker VLAN** (the Pi boot ROM
    emits untagged frames).
 5. UniFi firewall: allow worker→baradur TCP 2049 + UDP 67/69/4011; worker→WAN for image pulls.
+6. `sudo nixos-rebuild switch --flake .#baradur` (or `task switch:nixos`) — activates dnsmasq
+   proxy-DHCP/TFTP, the NFSv4 exports, the VLAN sub-interface, and the binfmt gate above.
+   Verify: `systemctl is-active dnsmasq nfs-server` → `active`; `ip -br addr show enp42s0.30`
+   shows `10.0.30.2/24`; `exportfs -v` lists both exports.
 
-## Pre-seed sops identity (per host, before first boot)
+## Bootstrap order (first boot, per host)
 
-```bash
-ssh-keygen -t ed25519 -N "" -f /tmp/<host>-seed/ssh_host_ed25519_key
-AGE=$(nix shell nixpkgs#ssh-to-age -c sh -c 'ssh-to-age < /tmp/<host>-seed/ssh_host_ed25519_key.pub')
-# add $AGE to .sops.yaml as &<host>; encrypt secrets/<host>.yaml (password) +
-# secrets/k3s-cluster.yaml (token, key group [worker, agent, arrayofone]); commit.
-# Format K3S_STATE (ext4, label K3S_STATE) with ssh/ sops-nix/ rancher/ subdirs;
-# copy the seed key into ssh/ so the FIRST activation can decrypt (no circularity).
-```
+Run once per Pi (`<host>` = `worker` or `agent`), after UniFi step 6 above:
 
-## EEPROM (one-time, while SD-booted)
-
-```bash
-sudo rpi-eeprom-config --edit   # BOOT_ORDER=0xf21 (SD then network), TFTP_PREFIX=1 (MAC subdir)
-```
+1. `task netboot:seed HOST=<host>` — generates `/tmp/<host>-seed/ssh_host_ed25519_key`(`.pub`)
+   and prints the host's derived age public key.
+2. Replace the `PLACEHOLDER_AGE_PUBLIC_KEY` for `&<host>` in `.sops.yaml` with the key from
+   step 1.
+3. `sops updatekeys secrets/k3s-cluster.yaml` — adds `<host>` to the shared token's recipient
+   set (the `.sops.yaml` rule carries a `# bootstrap: add *worker, *agent …` comment marking
+   this step; `nix shell nixpkgs#sops -c sops updatekeys …` if `sops` isn't on PATH).
+4. Create `secrets/<host>.yaml`, carrying the user password the always-on module expects
+   (June plan Task 8 Step 4; run from the repo root so `.sops.yaml`'s new rule applies):
+   ```bash
+   printf 'system:\n  users:\n    arrayofone:\n      password: %s\n' "$(mkpasswd -m sha-512)" \
+     | sops --encrypt --input-type yaml --output-type yaml /dev/stdin > secrets/<host>.yaml
+   ```
+   (`secrets/k3s-cluster.yaml` — the shared k3s token — already exists; step 3 above just adds
+   `<host>` as a recipient.)
+5. Format the `K3S_STATE` device (ext4, label `K3S_STATE`); create `ssh/`, `sops-nix/`,
+   `rancher/` subdirs; copy step 1's key pair into `ssh/` — this pre-seeds the identity so the
+   Pi's **first** activation can decrypt its secrets (no bootstrap circularity). For a first
+   `local`-rung boot, also format a `NIXOS_SD`-labelled root partition.
+6. `task netboot:sdimage HOST=<host>` — builds the sdImage artifact (binfmt-gated) and echoes
+   the flash hint.
+7. Flash: `sudo dd if=<sdImage>/sd-image/*.img of=/dev/sdX bs=4M status=progress conv=fsync`.
+   Insert into the Pi and boot.
+8. EEPROM (one-time, while SD-booted):
+   ```bash
+   sudo rpi-eeprom-config --edit   # BOOT_ORDER=0xf21 (SD then network), TFTP_PREFIX=1 (MAC subdir)
+   ```
+   **Pi 5 (`agent`) only:** confirm the bootloader EEPROM is netboot-capable before relying on
+   the `nfs`/`ram` rungs — `sudo rpi-eeprom-update -a` reports current vs. latest; run
+   `sudo rpi-eeprom-update -d -a` to apply an update if the network boot order digit isn't
+   accepted (early Pi 5 EEPROM revisions predate netboot support).
+9. On the Pi: `sudo k3s kubectl get nodes` → one `Ready` node.
+10. From baradur: `task kubeconfig:fetch IP=<pi-vlan-ip>` (worker → `10.0.30.11`), then
+    `export KUBECONFIG=~/.kube/worker.yaml && kubectl get nodes`.
 
 ## Per-mode deploy loop
 
@@ -56,15 +131,41 @@ known-good `local` SD inserted.
 ## kubeconfig (drive the cluster from baradur)
 
 ```bash
-ssh arrayofone@<worker-ip> sudo cat /etc/rancher/k3s/k3s.yaml \
-  | sed 's#https://127.0.0.1:6443#https://<worker-ip>:6443#' > ~/.kube/worker.yaml
+task kubeconfig:fetch IP=<worker-vlan-ip>   # worker: 10.0.30.11
 export KUBECONFIG=~/.kube/worker.yaml && kubectl get nodes
 ```
+
+Equivalent by hand, if the task target is unavailable:
+
+```bash
+ssh arrayofone@<worker-ip> sudo cat /etc/rancher/k3s/k3s.yaml \
+  | sed 's#https://127.0.0.1:6443#https://<worker-ip>:6443#' > ~/.kube/worker.yaml
+```
+
+## x86_64 worker (future)
+
+`fellowship.netboot.clients` already carries an `arch` option (`"rpi"` default,
+`"x86_64-efi"` for a UEFI PXE client) — baradur's dnsmasq proxy-DHCP/`pxe-service` answers
+the EFI64 `client-arch` tags (7/9) and per-EFI-client `systemd.tmpfiles` rules already
+symlink `ipxe.efi` + a chainloading `netboot.ipxe` into `<tftpRoot>/<mac>/` for any client
+with `arch = "x86_64-efi"`. The one piece deliberately **not** provided: `config.ipxe` itself
+— a future x86_64 artifact-pipeline target owns generating and publishing it, the same
+"artifact pipeline owns it" contract the Pis' `current` symlink follows. That whole EFI path
+is marked `# ON-HARDWARE-TUNABLE` in `modules/nixos/netboot/default.nix` — proxy-DHCP + UEFI
+PXE is firmware-sensitive and untested until an actual x86_64 box shows up.
 
 ## Known hardware-validation items (the netboot frontier)
 
 - The materialized NFS **root export** for `nfs` mode (a real `/` tree, not a store copy).
 - `vers=3` vs `vers=4.1` over the kernel `nfsroot` on the RPi initrd.
-- Exact `configTxtPackage` attr name; generated `config.txt` must name `Image`.
+- Exact `configTxtPackage` attr name; generated `config.txt` must name `Image`. (The Taskfile's
+  `netboot:host` falls back to `nixpkgs#raspberrypifw` + a hand-written `config.txt` today,
+  since the kernel verdict above is RED and the vendor `firmwarePackage`/`configTxtPackage`
+  attrs never evaluate.)
 - `netbootRamdisk` boots over the Pi firmware's TFTP for `ram` mode.
-- `bcmgenet`/`macb` built-in vs module; Pi 5 EEPROM netboot capability.
+- `bcmgenet`/`macb` built-in vs module; Pi 5 EEPROM netboot capability (bootstrap step 8 above).
+- NFS pseudo-root vs. absolute export path for the `nfs.csi.k8s.io` StorageClass `share` and
+  the etcd-snapshot NFS mount (both currently `/k8s-pvcs`, marked `ON-HARDWARE-VALIDATE` in
+  `modules/nixos/worker/default.nix`).
+- Proxy-DHCP + UEFI PXE handshake for the x86_64-EFI client path (see above) — untested,
+  firmware-sensitive.

--- a/docs/superpowers/plans/2026-06-21-pi-netboot-runbook.md
+++ b/docs/superpowers/plans/2026-06-21-pi-netboot-runbook.md
@@ -54,10 +54,12 @@ a Pi once it's off `local`.
 
 Nothing aarch64 builds on baradur — not `worker`/`agent` toplevel, not sdImages, not netboot
 artifacts — until **baradur's own first `switch`** activates `fellowship.netboot`'s binfmt
-registration (`/proc/sys/fs/binfmt_misc/qemu-aarch64` is empty until then). Every
-`task netboot:*` target checks that path first and exits 1 if it's missing. So the first
-hardware step, always, is switching baradur (UniFi step 5 / bootstrap step 1 below) —
-everything aarch64 depends on it transitively.
+registration (`/proc/sys/fs/binfmt_misc/qemu-aarch64` is empty until then). Of the `netboot:*`
+targets, `task netboot:host` and `task netboot:sdimage` check that path first and exit 1 if
+it's missing (both build aarch64 closures); `task netboot:seed` needs no gate — it only
+generates a host key + age identity, no aarch64 build involved. So the first hardware step,
+always, is switching baradur (UniFi step 5 / bootstrap step 1 below) — everything aarch64
+depends on it transitively.
 
 ## UniFi / switch (Phase 1)
 
@@ -105,7 +107,7 @@ Run once per Pi (`<host>` = `worker` or `agent`), after UniFi step 6 above:
    Insert into the Pi and boot.
 8. EEPROM (one-time, while SD-booted):
    ```bash
-   sudo rpi-eeprom-config --edit   # BOOT_ORDER=0xf21 (SD then network), TFTP_PREFIX=1 (MAC subdir)
+   sudo rpi-eeprom-config --edit   # BOOT_ORDER=0xf21 (SD then network), TFTP_PREFIX=1 (no client-side prefix; dnsmasq adds the per-MAC subdir server-side)
    ```
    **Pi 5 (`agent`) only:** confirm the bootloader EEPROM is netboot-capable before relying on
    the `nfs`/`ram` rungs — `sudo rpi-eeprom-update -a` reports current vs. latest; run
@@ -119,8 +121,10 @@ Run once per Pi (`<host>` = `worker` or `agent`), after UniFi step 6 above:
 
 - **local** — build + `nixos-rebuild switch --flake .#<host>` ON the Pi (normal on-disk).
 - **nfs / ram** — apply changes on **baradur**: `task netboot:host HOST=<host> MODE=<nfs|ram>
-  MAC=<lowercase:colon:mac>` rebuilds the closure, repopulates `/srv/netboot/<mac>/<gen>/`,
+  MAC=<lowercase-dash-mac>` rebuilds the closure, repopulates `/srv/netboot/<mac>/<gen>/`,
   flips the `current` symlink, then **power-cycle the Pi**. Never `switch` on the Pi.
+  `MAC` is dnsmasq's `tftp-unique-root=mac` form — lowercase, dash-separated
+  (e.g. `dc-a6-32-01-02-03`), not colon-separated.
 
 ## Brick recovery
 

--- a/flake.lock
+++ b/flake.lock
@@ -834,11 +834,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1784434257,
-        "narHash": "sha256-Feyvs5OkNaiG2ymUdOxWirTy9/HPJopywhnwlBIAPiY=",
+        "lastModified": 1785602337,
+        "narHash": "sha256-lWfCgeR+zfKOm8i4uqxCD47j5f753izd1d96/d9hTd4=",
         "owner": "nvmd",
         "repo": "nixos-raspberrypi",
-        "rev": "2bbb6ee54ed431a59b38d8aa1e254a9e848b7f2b",
+        "rev": "67616c24ed74573750f4864abfc358296a077466",
         "type": "github"
       },
       "original": {
@@ -881,11 +881,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1784280462,
-        "narHash": "sha256-DtoqIqM7VkR6NxAkcLpMwmi02USwWb3JdmNGLyhthc0=",
+        "lastModified": 1785491804,
+        "narHash": "sha256-p00vplVOyfKGlhju0+eGGPAxyYYKaY0lpyuoHLFIx2Y=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "293d6abedf0478e681a4dfcfcb35b30fc796a32f",
+        "rev": "5b4f72e1705a63aace42900610c4db82cb4af0ec",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -136,6 +136,16 @@
         )
       ];
 
+      # @gitian:host worker — aarch64-linux RPi4, diskless k3s server. Retested
+      # 2026-08-01 against nixos-raspberrypi HEAD (67616c2, 2026-08-01):
+      # `raspberry-pi-4.base` still fails to evaluate on a bare `with inputs;`
+      # module injection — the vendor module itself requires a `nixos-raspberrypi`
+      # special arg bound to its own flake `self` (its own flake.nix wires
+      # `specialArgs = inputs // { nixos-raspberrypi = self; }`), which Snowfall
+      # Lib's system builder does not provide (it nests inputs under
+      # `specialArgs.inputs`, not a flat `nixos-raspberrypi` arg). Mainline
+      # kernel stands; see the worker host's commit body for the exact error.
+
       # @gitian:host agent — aarch64-linux RPi5, currently on the mainline
       # kernel (its unpinned third-party nix-rpi5 fetchTarball broke pure
       # evaluation and was removed). The vendor kernel/firmware comes back via

--- a/flake.nix
+++ b/flake.nix
@@ -145,6 +145,10 @@
       # Lib's system builder does not provide (it nests inputs under
       # `specialArgs.inputs`, not a flat `nixos-raspberrypi` arg). Mainline
       # kernel stands; see the worker host's commit body for the exact error.
+      # Deep-review shim test: injecting `{ _module.args.nixos-raspberrypi = nixos-raspberrypi; }`
+      # clears the missing-arg error, but evaluation then fails with
+      # `attribute 'buildDTBs' missing` (device-tree.nix vs the vendor kernel) — the July
+      # incompatibility persists at HEAD 67616c2, so mainline stands on both layers.
 
       # @gitian:host agent — aarch64-linux RPi5, currently on the mainline
       # kernel (its unpinned third-party nix-rpi5 fetchTarball broke pure

--- a/modules/nixos/netboot/default.nix
+++ b/modules/nixos/netboot/default.nix
@@ -1,4 +1,4 @@
-{ lib, config, namespace, ... }:
+{ lib, config, pkgs, namespace, ... }:
 let
   cfg = config.${namespace}.netboot;
   vlanIface = "${cfg.parentInterface}.${toString cfg.vlan}";
@@ -6,6 +6,19 @@ let
   prefix = lib.toInt (lib.last (lib.splitString "/" cfg.serverAddress));
   octets = lib.splitString "." hostIp;
   netAddr = "${lib.concatStringsSep "." (lib.take 3 octets)}.0"; # /24 only — asserted below
+
+  # EFI clients boot iPXE from <tftpRoot>/<mac>/ (tftp-unique-root=mac). The chainload script is
+  # identical for every EFI client — it just hands off to config.ipxe, which THIS module does not
+  # create: the artifact pipeline (T6, and the future x86 target) owns it, same contract as the
+  # Pis' `current` symlink.
+  netbootIpxeScript = pkgs.writeText "netboot.ipxe" "#!ipxe\nchain --autofree config.ipxe\n";
+  efiClients = lib.filterAttrs (_: c: c.arch == "x86_64-efi") cfg.clients;
+  efiTftpRules = lib.concatMap
+    (c: [
+      "L+ ${toString cfg.tftpRoot}/${c.mac}/ipxe.efi - - - - ${pkgs.ipxe}/ipxe.efi"
+      "L+ ${toString cfg.tftpRoot}/${c.mac}/netboot.ipxe - - - - ${netbootIpxeScript}"
+    ])
+    (lib.attrValues efiClients);
 in
 {
   options.${namespace}.netboot = {
@@ -44,11 +57,19 @@ in
       description = "Known Pi netboot clients keyed by hostname.";
       type = lib.types.attrsOf (lib.types.submodule {
         options = {
-          serial = lib.mkOption { type = lib.types.str; };
+          serial = lib.mkOption {
+            type = lib.types.str;
+            default = ""; # meaningless for EFI clients
+          };
           mac = lib.mkOption { type = lib.types.str; };
           address = lib.mkOption {
             type = lib.types.str;
             description = "UniFi-reserved IP for this Pi.";
+          };
+          arch = lib.mkOption {
+            type = lib.types.enum [ "rpi" "x86_64-efi" ];
+            default = "rpi";
+            description = "Client boot path: Raspberry Pi Boot firmware, or UEFI HTTP/TFTP PXE.";
           };
         };
       });
@@ -96,8 +117,16 @@ in
         bind-interfaces = true;
         port = 0; # DHCP + TFTP only, no DNS
         dhcp-range = [ "${netAddr},proxy" ];
-        dhcp-match = [ "set:rpi,option:client-arch,0" ];
-        pxe-service = [ "tag:rpi,0,Raspberry Pi Boot" ];
+        # ON-HARDWARE-TUNABLE: proxy-DHCP + UEFI PXE is firmware-sensitive; validated when the x86_64 box arrives.
+        dhcp-match = [
+          "set:rpi,option:client-arch,0"
+          "set:efi64,option:client-arch,7"
+          "set:efi64,option:client-arch,9"
+        ];
+        pxe-service = [
+          "tag:rpi,0,Raspberry Pi Boot"
+          "tag:efi64,x86-64_EFI,\"iPXE\",ipxe.efi"
+        ];
         enable-tftp = true;
         tftp-root = toString cfg.tftpRoot;
         tftp-unique-root = "mac"; # serve <tftpRoot>/<mac>/ per client (pair with EEPROM TFTP_PREFIX=1)
@@ -126,13 +155,16 @@ in
         69 # TFTP
         4011 # proxy-DHCP
       ];
-      allowedTCPPorts = [ 2049 ]; # NFSv4
+      allowedTCPPorts = [
+        2049 # NFSv4
+        3100 # Loki push — fellowship.worker targets http://<bootServer>:3100
+      ];
     };
 
     systemd.tmpfiles.rules = [
       "d ${toString cfg.tftpRoot} 0755 dnsmasq dnsmasq - -"
       "d ${toString cfg.rootStore} 0755 root root - -"
       "d ${toString cfg.pvcExport} 0777 root root - -"
-    ];
+    ] ++ efiTftpRules;
   };
 }

--- a/modules/nixos/netboot/default.nix
+++ b/modules/nixos/netboot/default.nix
@@ -61,7 +61,10 @@ in
             type = lib.types.str;
             default = ""; # meaningless for EFI clients
           };
-          mac = lib.mkOption { type = lib.types.str; };
+          mac = lib.mkOption {
+            type = lib.types.str;
+            description = "Client MAC, lowercase dash-separated (dnsmasq tftp-unique-root form, e.g. dc-a6-32-01-02-03).";
+          };
           address = lib.mkOption {
             type = lib.types.str;
             description = "UniFi-reserved IP for this Pi.";
@@ -118,14 +121,19 @@ in
         port = 0; # DHCP + TFTP only, no DNS
         dhcp-range = [ "${netAddr},proxy" ];
         # ON-HARDWARE-TUNABLE: proxy-DHCP + UEFI PXE is firmware-sensitive; validated when the x86_64 box arrives.
+        # tag negation on pxe-service + user-class match is the standard dnsmasq iPXE break-out
+        # (without it, iPXE re-DHCPs, matches client-arch again, and is handed ipxe.efi forever
+        # instead of netboot.ipxe) — validate on the real box.
         dhcp-match = [
           "set:rpi,option:client-arch,0"
           "set:efi64,option:client-arch,7"
           "set:efi64,option:client-arch,9"
+          "set:ipxe,option:user-class,iPXE"
         ];
         pxe-service = [
           "tag:rpi,0,Raspberry Pi Boot"
-          "tag:efi64,x86-64_EFI,\"iPXE\",ipxe.efi"
+          "tag:efi64,tag:!ipxe,x86-64_EFI,\"iPXE\",ipxe.efi"
+          "tag:ipxe,x86-64_EFI,\"netboot config\",netboot.ipxe"
         ];
         enable-tftp = true;
         tftp-root = toString cfg.tftpRoot;

--- a/modules/nixos/worker/default.nix
+++ b/modules/nixos/worker/default.nix
@@ -95,16 +95,19 @@ in
     };
     fileSystems."/etc/ssh" = {
       device = "/state/ssh";
+      fsType = "none";
       options = [ "bind" ];
       neededForBoot = true;
     };
     fileSystems."/var/lib/sops-nix" = {
       device = "/state/sops-nix";
+      fsType = "none";
       options = [ "bind" ];
       neededForBoot = true;
     };
     fileSystems."/var/lib/rancher/k3s" = {
       device = "/state/rancher";
+      fsType = "none";
       options = [ "bind" ];
     };
 
@@ -136,6 +139,7 @@ in
               namespace = "kube-system";
             };
             spec = {
+              # chart version floats — pin after the first successful install (ON-HARDWARE)
               chart = "csi-driver-nfs";
               repo = "https://raw.githubusercontent.com/kubernetes-csi/csi-driver-nfs/master/charts";
               targetNamespace = "kube-system";
@@ -165,7 +169,7 @@ in
       description = "k3s embedded etcd snapshot";
       serviceConfig = {
         Type = "oneshot";
-        ExecStart = "${pkgs.k3s}/bin/k3s etcd-snapshot save --snapshot-dir /mnt/etcd-snapshots";
+        ExecStart = "${pkgs.k3s}/bin/k3s etcd-snapshot save --dir /mnt/etcd-snapshots";
       };
     };
     systemd.timers.k3s-etcd-snapshot = lib.mkIf (cfg.k3s.role == "server") {

--- a/modules/nixos/worker/default.nix
+++ b/modules/nixos/worker/default.nix
@@ -124,10 +124,61 @@ in
           "--write-kubeconfig-mode=0600" # admin creds not world-readable
           "--cluster-init" # embedded etcd so `etcd-snapshot` works
         ];
+        # In-cluster NFS provisioner client — csi-driver-nfs via k3s auto-deploy manifest, plus
+        # the StorageClass PVCs bind against. Server-only: agents don't run the k3s
+        # apiserver/controller that consumes manifests/.
+        manifests.nfs-csi.content = [
+          {
+            apiVersion = "helm.cattle.io/v1";
+            kind = "HelmChart";
+            metadata = {
+              name = "csi-driver-nfs";
+              namespace = "kube-system";
+            };
+            spec = {
+              chart = "csi-driver-nfs";
+              repo = "https://raw.githubusercontent.com/kubernetes-csi/csi-driver-nfs/master/charts";
+              targetNamespace = "kube-system";
+            };
+          }
+          {
+            apiVersion = "storage.k8s.io/v1";
+            kind = "StorageClass";
+            metadata.name = "nfs";
+            provisioner = "nfs.csi.k8s.io";
+            parameters = {
+              server = cfg.bootServer;
+              share = "/k8s-pvcs"; # ON-HARDWARE-VALIDATE: NFSv4 pseudo-root path vs absolute export path
+            };
+            reclaimPolicy = "Delete";
+            mountOptions = [ "nfsvers=4.1" ];
+          }
+        ];
       })
       cfg.k3s.extraConfig
     ];
     networking.firewall.allowedTCPPorts = lib.mkIf (cfg.k3s.role == "server") [ 6443 ];
+
+    # etcd snapshots must live OFF the K3S_STATE device (its loss is what they insure against),
+    # hence NFS to baradur. Server-only: agents run no etcd to snapshot.
+    systemd.services.k3s-etcd-snapshot = lib.mkIf (cfg.k3s.role == "server") {
+      description = "k3s embedded etcd snapshot";
+      serviceConfig = {
+        Type = "oneshot";
+        ExecStart = "${pkgs.k3s}/bin/k3s etcd-snapshot save --snapshot-dir /mnt/etcd-snapshots";
+      };
+    };
+    systemd.timers.k3s-etcd-snapshot = lib.mkIf (cfg.k3s.role == "server") {
+      description = "Daily k3s embedded etcd snapshot";
+      wantedBy = [ "timers.target" ];
+      timerConfig.OnCalendar = "03:30";
+    };
+    # soft+automount so an unreachable baradur can't hang boots.
+    fileSystems."/mnt/etcd-snapshots" = lib.mkIf (cfg.k3s.role == "server") {
+      device = "${cfg.bootServer}:/k8s-pvcs/etcd-snapshots"; # ON-HARDWARE-VALIDATE: same pseudo-root caveat as the StorageClass share.
+      fsType = "nfs";
+      options = [ "nfsvers=4.1" "soft" "x-systemd.automount" "x-systemd.idle-timeout=300" "noauto" ];
+    };
 
     environment.systemPackages = [
       pkgs.k3s

--- a/secrets/k3s-cluster.yaml
+++ b/secrets/k3s-cluster.yaml
@@ -1,0 +1,17 @@
+k3s:
+    token: ENC[AES256_GCM,data:sHkqYK0lnoH5Svb6hU4oa4GGcFwNFzz/FTuFysgZyd2kEcKMqHPYGO2NYuw=,iv:2tmerJ1CTvLh1XXmA1UuRM/M5PosjW1I8chDxNjvPGo=,tag:4Ftsp0kBeHsWBr99Fqp/DQ==,type:str]
+sops:
+    age:
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBxUUkyenpsRHk3M3NkOW9a
+            NndOTzNaa0ZlUnB0d2lFNUsxMzdINU55U0h3CnZ1OEFBR01idEV3WXU5UDRBRnRX
+            ajRQYzBXZlFNWDFvS1lhQVoxajVtQmsKLS0tIFFqNmZLZXdqQTk4V3lhZkhiMmFJ
+            U0pZZ0hrRVNtSktRZS93TWNlWVlVWVUKBSzN/dydE5NL0Poh+7BOEnQJpNh/+f2O
+            x1xSjbXiU3ia+iDjlji2oORYyXp6sKGi3qnR+sPEJZ+FYXeA4Vg52A==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age19r87m08mt03zg8ustzlx733s4m4wph6vvkd0qxlequfje5k0mawsy68vp2
+    lastmodified: "2026-08-01T23:32:59Z"
+    mac: ENC[AES256_GCM,data:x+7CgVdXsvjO/7Gu0yC4Jl+cjTdXYXN0Azn+MT5Zi/+3jxo4+nrynXPvz8vsl/kU0gt19AZQxh2/z4FQnDVcn1DSrrSgE51vJ6ZCv0xfuvBK+vQ9VnIUnldknB4dL7KfSdBLxVfyLUX/Qg51mWZ/c+PTqquhnD54lXfNYyQyJZE=,iv:8O4yq047mrOnQdFuLT2NoLyV9K6Dj8gyaF9u8RKbANs=,tag:NGMHdwaA9aytCW7QkAi2Mw==,type:str]
+    unencrypted_suffix: _unencrypted
+    version: 3.13.3

--- a/systems/aarch64-linux/agent/default.nix
+++ b/systems/aarch64-linux/agent/default.nix
@@ -34,13 +34,6 @@ in
     };
   };
   sops.secrets."k3s/token".sopsFile = ../../../secrets/k3s-cluster.yaml;
-  # modules/nixos/worker's bind mounts (/etc/ssh, /var/lib/sops-nix,
-  # /var/lib/rancher/k3s — PR #5, out of this task's file scope) predate current
-  # nixpkgs requiring fileSystems.<name>.fsType explicitly (no more "auto"
-  # default); host-level override, standard bind-mount idiom (same fix as worker).
-  fileSystems."/etc/ssh".fsType = "none";
-  fileSystems."/var/lib/sops-nix".fsType = "none";
-  fileSystems."/var/lib/rancher/k3s".fsType = "none";
 
   networking.hostName = "agent";
   system.stateVersion = "24.05";

--- a/systems/aarch64-linux/agent/default.nix
+++ b/systems/aarch64-linux/agent/default.nix
@@ -1,40 +1,47 @@
-{ pkgs, ... }:
+{ config, lib, modulesPath, ... }:
+let
+  # BOOTSTRAP LADDER — flip "local" -> "nfs" -> "ram" per the runbook, one rung per commit.
+  rootMode = "local";
+in
 {
-  # Mainline kernel for now. The previous unpinned fetchTarball of a
-  # third-party nix-rpi5 repo broke pure evaluation; the vendor Pi 5
-  # kernel/firmware returns via nixos-raspberrypi in the pi-netboot plan's
-  # Phase 5 (see flake.nix note on the current upstream incompatibility).
+  imports =
+    lib.optional (rootMode == "local") "${modulesPath}/installer/sd-card/sd-image-aarch64.nix"
+    ++ lib.optional (rootMode == "ram") "${modulesPath}/installer/netboot/netboot.nix";
 
-  # SD boot via the firmware's extlinux path, as on the stock aarch64 sd-image
+  # RETEST VERDICT (2026-08-01, mirrored from the worker/pi4 host — see its commit body
+  # for the exact eval error): nixos-raspberrypi's `raspberry-pi-5.base` module carries the
+  # same Snowfall specialArgs incompatibility as `raspberry-pi-4.base` (requires a
+  # `nixos-raspberrypi` special arg bound to its own flake `self`, which Snowfall Lib's
+  # system builder does not provide). Mainline kernel stands, same as before this migration
+  # — the worker profile is kernel-agnostic, so no flake.nix injection is added.
   boot.loader.grub.enable = false;
   boot.loader.generic-extlinux-compatible.enable = true;
 
-  # Standard Pi sd-image layout; superseded by the fellowship.worker root
-  # modes when the netboot plan's Phase 5 lands.
-  fileSystems."/" = {
-    device = "/dev/disk/by-label/NIXOS_SD";
-    fsType = "ext4";
-  };
-
-  networking = { };
-
-  fellowship.monitoring.agent.enable = true;
-
-  nix = {
-    settings.experimental-features = "nix-command flakes";
-    gc = {
-      automatic = true;
-      dates = "03:15";
+  fellowship.worker = {
+    enable = true;
+    board = "pi5";
+    bootServer = "10.0.30.2";
+    root = {
+      mode = rootMode;
+      target = if rootMode == "local" then "/dev/disk/by-label/NIXOS_SD"
+               else "10.0.30.2:/mnt/node/netboot-roots/agent";
+    };
+    k3s = {
+      role = "agent";
+      target = "https://10.0.30.11:6443";
+      tokenFile = config.sops.secrets."k3s/token".path;
+      stateDevice = "/dev/disk/by-label/K3S_STATE";
     };
   };
+  sops.secrets."k3s/token".sopsFile = ../../../secrets/k3s-cluster.yaml;
+  # modules/nixos/worker's bind mounts (/etc/ssh, /var/lib/sops-nix,
+  # /var/lib/rancher/k3s — PR #5, out of this task's file scope) predate current
+  # nixpkgs requiring fileSystems.<name>.fsType explicitly (no more "auto"
+  # default); host-level override, standard bind-mount idiom (same fix as worker).
+  fileSystems."/etc/ssh".fsType = "none";
+  fileSystems."/var/lib/sops-nix".fsType = "none";
+  fileSystems."/var/lib/rancher/k3s".fsType = "none";
 
-  nixpkgs.config.allowUnfree = true;
-
-  services.openssh.enable = true;
-
-  i18n.defaultLocale = "en_CA.UTF-8";
-
-  time.timeZone = "America/Vancouver";
-
+  networking.hostName = "agent";
   system.stateVersion = "24.05";
 }

--- a/systems/aarch64-linux/worker/default.nix
+++ b/systems/aarch64-linux/worker/default.nix
@@ -1,0 +1,45 @@
+{ config, lib, modulesPath, ... }:
+let
+  # BOOTSTRAP LADDER — flip "local" -> "nfs" -> "ram" per the runbook, one rung per commit.
+  rootMode = "local";
+in
+{
+  imports =
+    [ ./hardware-configuration.nix ]
+    ++ lib.optional (rootMode == "local") "${modulesPath}/installer/sd-card/sd-image-aarch64.nix"
+    ++ lib.optional (rootMode == "ram") "${modulesPath}/installer/netboot/netboot.nix";
+
+  # RETEST VERDICT (2026-08-01): nixos-raspberrypi HEAD (67616c2) still fails to
+  # evaluate under this flake's Snowfall-driven specialArgs contract — the vendor
+  # `raspberry-pi-4.base` module requires a `nixos-raspberrypi` special arg bound
+  # to its own flake self, which Snowfall Lib doesn't provide via a bare
+  # `worker.modules = with inputs; [ ... ]` injection (exact error in the commit
+  # body). Falling back to the mainline kernel, same as the existing `agent`
+  # stub — the worker profile is kernel-agnostic.
+  boot.loader.grub.enable = false;
+  boot.loader.generic-extlinux-compatible.enable = true;
+
+  fellowship.worker = {
+    enable = true;
+    board = "pi4";
+    bootServer = "10.0.30.2";
+    # No operator SSH key found in-repo (dbook/mingabook carry empty authorizedKeys lists too) —
+    # left unset (default [ ]); fill in at bootstrap per the runbook.
+    root = {
+      mode = rootMode;
+      target = if rootMode == "local" then "/dev/disk/by-label/NIXOS_SD"
+               else "10.0.30.2:/mnt/node/netboot-roots/worker";
+    };
+    k3s = { role = "server"; stateDevice = "/dev/disk/by-label/K3S_STATE"; };
+  };
+  # modules/nixos/worker's bind mounts (/etc/ssh, /var/lib/sops-nix,
+  # /var/lib/rancher/k3s — PR #5, out of T1's file scope) predate current
+  # nixpkgs requiring fileSystems.<name>.fsType explicitly (no more "auto"
+  # default); host-level override, standard bind-mount idiom.
+  fileSystems."/etc/ssh".fsType = "none";
+  fileSystems."/var/lib/sops-nix".fsType = "none";
+  fileSystems."/var/lib/rancher/k3s".fsType = "none";
+
+  networking.hostName = "worker";
+  system.stateVersion = "24.05";
+}

--- a/systems/aarch64-linux/worker/default.nix
+++ b/systems/aarch64-linux/worker/default.nix
@@ -37,13 +37,6 @@ in
     };
   };
   sops.secrets."k3s/token".sopsFile = ../../../secrets/k3s-cluster.yaml;
-  # modules/nixos/worker's bind mounts (/etc/ssh, /var/lib/sops-nix,
-  # /var/lib/rancher/k3s — PR #5, out of T1's file scope) predate current
-  # nixpkgs requiring fileSystems.<name>.fsType explicitly (no more "auto"
-  # default); host-level override, standard bind-mount idiom.
-  fileSystems."/etc/ssh".fsType = "none";
-  fileSystems."/var/lib/sops-nix".fsType = "none";
-  fileSystems."/var/lib/rancher/k3s".fsType = "none";
 
   networking.hostName = "worker";
   system.stateVersion = "24.05";

--- a/systems/aarch64-linux/worker/default.nix
+++ b/systems/aarch64-linux/worker/default.nix
@@ -30,8 +30,13 @@ in
       target = if rootMode == "local" then "/dev/disk/by-label/NIXOS_SD"
                else "10.0.30.2:/mnt/node/netboot-roots/worker";
     };
-    k3s = { role = "server"; stateDevice = "/dev/disk/by-label/K3S_STATE"; };
+    k3s = {
+      role = "server";
+      stateDevice = "/dev/disk/by-label/K3S_STATE";
+      tokenFile = config.sops.secrets."k3s/token".path;
+    };
   };
+  sops.secrets."k3s/token".sopsFile = ../../../secrets/k3s-cluster.yaml;
   # modules/nixos/worker's bind mounts (/etc/ssh, /var/lib/sops-nix,
   # /var/lib/rancher/k3s — PR #5, out of T1's file scope) predate current
   # nixpkgs requiring fileSystems.<name>.fsType explicitly (no more "auto"

--- a/systems/aarch64-linux/worker/hardware-configuration.nix
+++ b/systems/aarch64-linux/worker/hardware-configuration.nix
@@ -1,0 +1,9 @@
+# June plan Task 8 Step 1 verbatim. Written for the vendor `raspberry-pi-4.base`
+# module (kernel + raspberrypifw firmware + bootloader); the 2026-08-01 retest
+# (see the worker host's commit body) fell back to the mainline kernel instead
+# — boot.loader is set in ./default.nix. Kept minimal either way: no
+# fileSystems here, those are owned by the worker module (Task 6/7).
+{ lib, ... }:
+{
+  networking.useDHCP = lib.mkDefault true;
+}

--- a/systems/x86_64-linux/baradur/default.nix
+++ b/systems/x86_64-linux/baradur/default.nix
@@ -126,7 +126,20 @@
       };
       server = {
         enable = true;
-        nodeTargets = [ ]; # follow-up: helms-deep + pi workers once static addresses exist
+        nodeTargets = [ "10.0.30.11:9100" "10.0.30.12:9100" ]; # follow-up: helms-deep once static address exists
+      };
+    };
+
+    netboot = {
+      enable = true;
+      parentInterface = "enp42s0";
+      vlan = 30;
+      serverAddress = "10.0.30.2/24";
+      rootStore = "/mnt/node/netboot-roots";
+      pvcExport = "/mnt/node/k8s-pvcs";
+      clients = {
+        worker = { mac = ""; address = "10.0.30.11"; };  # mac filled at bootstrap (dnsmasq logs it)
+        agent  = { mac = ""; address = "10.0.30.12"; };
       };
     };
   };

--- a/systems/x86_64-linux/baradur/default.nix
+++ b/systems/x86_64-linux/baradur/default.nix
@@ -138,7 +138,7 @@
       rootStore = "/mnt/node/netboot-roots";
       pvcExport = "/mnt/node/k8s-pvcs";
       clients = {
-        worker = { mac = ""; address = "10.0.30.11"; };  # mac filled at bootstrap (dnsmasq logs it)
+        worker = { mac = ""; address = "10.0.30.11"; };  # mac filled at bootstrap, lowercase dash-separated (dnsmasq logs it)
         agent  = { mac = ""; address = "10.0.30.12"; };
       };
     };


### PR DESCRIPTION
Resumes the June pi-netboot plan (PR #5 landed the modules; this executes the unbuilt half) under the settled worker-fleet design.

## What's in here (12 commits)
- **baradur as netboot provider**: `fellowship.netboot` enabled — VLAN 30 on `enp42s0` (10.0.30.2/24), proxy-DHCP + TFTP + NFSv4, arch-aware clients (future x86_64 box boots via iPXE from the same dnsmasq), Loki 3100 opening, Pi scrape targets in monitoring.
- **Pi 4 `worker` (k3s server) + Pi 5 `agent` (k3s agent)** on the `fellowship.worker` profile, with a single-let `local → nfs → ram` bootstrap ladder per host.
- **Kernel verdict: mainline.** nixos-raspberrypi HEAD retested RED at two layers (Snowfall specialArgs, then the July `buildDTBs` incompatibility underneath — shim-tested); evidence in flake.nix.
- **Taskfile artifact pipeline**: `netboot:host`, `netboot:sdimage`, `netboot:seed`, `kubeconfig:fetch` — binfmt-gated, atomic `current` publish, keep-3 GC.
- **Secrets scaffolding**: encrypted shared k3s token, placeholder Pi age keys (helms-deep precedent), updatekeys flow in the runbook.
- **k3s extras**: csi-driver-nfs StorageClass manifest + nightly etcd snapshots to baradur NFS (server-role gated).
- **Runbook refreshed** with the settled values and full bootstrap order.

Deep-review fixes included: mandatory `init=` on generated cmdline.txt, k3s `--dir` flag, mainline DTB overlay, dash-separated MAC dirs (dnsmasq man-verified), iPXE re-DHCP loop break, bind-mount fsType DRY.

## Verification
- `nix build .#nixosConfigurations.baradur...toplevel` clean; `worker`/`agent` eval to drvPaths (aarch64 builds gated on first switch enabling binfmt).
- Rendered dnsmasq config passes `dnsmasq --test`; `task --list` parses.
- Live boot chain is hardware-frontier: proven rung-by-rung via the runbook ladder after switch (do not skip rungs).

KB: `worker-fleet-netboot-design` / `worker-fleet-netboot-plan` (implementation record + follow-ups).

https://claude.ai/code/session_013JDskYYQe1wwFj3UvAfRZ2