### PR TITLE
feat(baradur) open firewall port 4000

### DIFF
--- a/systems/x86_64-linux/baradur/default.nix
+++ b/systems/x86_64-linux/baradur/default.nix
@@ -275,6 +275,7 @@
   networking.firewall = {
     enable = true;
     allowedTCPPorts = [
+      4000
       11434
       8082
       5432


### PR DESCRIPTION
Adds TCP 4000 to baradur's `allowedTCPPorts`. One-liner, cut from master so it lands independently of the netboot round (no overlap with its baradur changes).

Verified: full baradur toplevel builds clean.

https://claude.ai/code/session_013JDskYYQe1wwFj3UvAfRZ2