### PR TITLE
fix(netboot) resolv.conf hijack + dnsmasq vlan start race

### DIFF
--- a/modules/nixos/netboot/default.nix
+++ b/modules/nixos/netboot/default.nix
@@ -115,6 +115,10 @@ in
     # Proxy-DHCP (coexists with UniFi DHCP) + TFTP, bound to the VLAN iface.
     services.dnsmasq = {
       enable = true;
+      # port = 0 below disables DNS entirely, but the NixOS module still defaults
+      # resolveLocalQueries to true — which rewrites /etc/resolv.conf to 127.0.0.1,
+      # where nothing answers. Took out all of baradur's DNS on first switch.
+      resolveLocalQueries = false;
       settings = {
         interface = vlanIface;
         bind-interfaces = true;
@@ -141,10 +145,14 @@ in
         log-dhcp = true;
       };
     };
-    # Order dnsmasq after the VLAN device exists (systemd keeps the literal dot in NIC unit names).
+    # Order dnsmasq after scripted networking has created AND addressed the VLAN
+    # iface (systemd keeps the literal dot in these unit names). Ordering against
+    # the passive .device unit alone was insufficient: bind-interfaces raced udev
+    # and dnsmasq's first start died with "unknown interface enp42s0.30".
     systemd.services.dnsmasq.after = [
       "network.target"
-      "sys-subsystem-net-devices-${vlanIface}.device"
+      "${vlanIface}-netdev.service"
+      "network-addresses-${vlanIface}.service"
     ];
 
     # NFSv4-only: the worker netboot root (ro) and the PVC store (rw, root-squashed).


### PR DESCRIPTION
## What broke on the first switch (gen 681)

Two independent faults took down the desktop login and "the internet":

### 1. No internet = total DNS outage (this PR fixes it)
`services.dnsmasq` defaults `resolveLocalQueries = true`, which rewrote `/etc/resolv.conf` to `name_servers='127.0.0.1 ::1'` — but the netboot dnsmasq runs `port = 0` (DHCP/TFTP only, **DNS disabled**). Every lookup died while IP routing was fine (baradur stayed on the trusted VLAN with its normal address/route the whole time; the VLAN 30 sub-iface is additive and never carried baradur's egress). Fix: `resolveLocalQueries = false`.

### 2. SDDM login loop (NOT a repo bug — caused by uncommitted flake.lock drift)
Auth succeeded every time; **Hyprland `0.56.0+date=2026-08-03_78e2f9b` segfaulted ~2s into each session** (two coredumps, crash in aquamarine's logger during libinput teardown). That Hyprland came from an uncommitted `nix flake update` in the working tree, not from anything merged. The drift is preserved in `git stash` ("aug-3 nix flake update drift…"); with a clean tree the committed lock pins hyprland `566ff8f` (Jul 24) — the same stack gen 678 ran Jul 24–28.

### Bonus hardening
dnsmasq's first start raced udev (`unknown interface enp42s0.30`, recovered only via restart) — now ordered after the scripted-networking netdev + address units.

## Verification
- `nix build .#nixosConfigurations.baradur...toplevel` from this branch succeeds (committed lock).
- Built `etc/resolvconf.conf` is byte-equivalent to known-good gen 680 (no 127.0.0.1).
- Built closure ships hyprland `2026-07-24_566ff8f`.

## After merge
`nixos-rebuild switch` **from a clean tree** (no modified flake.lock — `git status` first). Expected result: desktop as in gen 678/680, DNS intact, netboot stack (dnsmasq/NFS/binfmt) live on enp42s0.30.

https://claude.ai/code/session_013JDskYYQe1wwFj3UvAfRZ2